### PR TITLE
Pin the versions of the files we're using and allow offline use

### DIFF
--- a/pocket_tts/config/b6369a24.yaml
+++ b/pocket_tts/config/b6369a24.yaml
@@ -1,7 +1,7 @@
 # sig: b6369a24
 
-weights_path: hf://kyutai/pocket-tts/tts_b6369a24.safetensors
-weights_path_without_voice_cloning: hf://kyutai/pocket-tts-without-voice-cloning/tts_b6369a24.safetensors
+weights_path: hf://kyutai/pocket-tts/tts_b6369a24.safetensors@427e3d61b276ed69fdd03de0d185fa8a8d97fc5b
+weights_path_without_voice_cloning: hf://kyutai/pocket-tts-without-voice-cloning/tts_b6369a24.safetensors@d4fdd22ae8c8e1cb3634e150ebeff1dab2d16df3
 
 flow_lm:
   dtype: float32
@@ -18,7 +18,7 @@ flow_lm:
     dim: 1024
     n_bins: 4000
     tokenizer: sentencepiece
-    tokenizer_path: hf://kyutai/pocket-tts-without-voice-cloning/tokenizer.model
+    tokenizer_path: hf://kyutai/pocket-tts-without-voice-cloning/tokenizer.model@d4fdd22ae8c8e1cb3634e150ebeff1dab2d16df3
   #weights_path: flow_lm_b6369a24.safetensors
 
 mimi:

--- a/pocket_tts/models/flow_lm.py
+++ b/pocket_tts/models/flow_lm.py
@@ -2,7 +2,6 @@ import logging
 from functools import partial
 
 import torch
-import torch.export
 from beartype.typing import Callable
 from torch import nn
 from typing_extensions import Self

--- a/pocket_tts/utils/utils.py
+++ b/pocket_tts/utils/utils.py
@@ -14,7 +14,7 @@ PROJECT_ROOT = Path(__file__).parent.parent.parent
 _voices_names = ["alba", "marius", "javert", "jean", "fantine", "cosette", "eponine", "azelma"]
 PREDEFINED_VOICES = {
     # don't forget to change this
-    x: f"hf://kyutai/pocket-tts-without-voice-cloning/embeddings/{x}.safetensors"
+    x: f"hf://kyutai/pocket-tts-without-voice-cloning/embeddings/{x}.safetensors@d4fdd22ae8c8e1cb3634e150ebeff1dab2d16df3"
     for x in _voices_names
 }
 


### PR DESCRIPTION
Without a specific commit, huggingface cannot be sure that the file has not changed, so it needs to do a quick query to hf hub to check that there were no new commits. This adds some latency to the CLI and function calls, but it also prevents offline use, even if the files are already present locally. This PRs fixes this. Now with the commit hash, hf has the guarantee that the local files are the right ones and thus doesn't need to query the hub every time.

Fix https://github.com/kyutai-labs/pocket-tts/pull/21