### PR TITLE
fix: close temp file handle before deletion on Windows

### DIFF
--- a/pocket_tts/main.py
+++ b/pocket_tts/main.py
@@ -149,14 +149,15 @@ def text_to_speech(
         with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as temp_file:
             content = voice_wav.file.read()
             temp_file.write(content)
-            temp_file.flush()
+            temp_file_path = temp_file.name
+        # File is now closed after exiting the `with` block
 
-            try:
-                model_state = tts_model.get_state_for_audio_prompt(
-                    Path(temp_file.name), truncate=True
-                )
-            finally:
-                os.unlink(temp_file.name)
+        try:
+            model_state = tts_model.get_state_for_audio_prompt(
+                Path(temp_file_path), truncate=True
+            )
+        finally:
+            os.unlink(temp_file_path)
     else:
         # Use default global model state
         model_state = global_model_state


### PR DESCRIPTION
On Windows, files cannot be deleted while a handle is still open. The previous code called os.unlink() inside the `with` block, where the NamedTemporaryFile handle was still open, causing:

> PermissionError: [WinError 32] The process cannot access the file because it is being used by another process

This fix moves the try/finally block outside the `with` statement, ensuring the file handle is closed before attempting to read and delete the file. This makes the code work correctly on Windows while maintaining the same behavior on Linux/macOS.

`uvx pre-commit run --all-files` passing

<img width="973" height="128" alt="image" src="https://github.com/user-attachments/assets/495391e3-c71b-41e5-9c60-598919bf2248" />
