### PR TITLE
Add 'Projects Using' Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ We accept contributions! Feel free to open issues or pull requests on GitHub.
 You can find development instructions in the [CONTRIBUTING.md](https://github.com/kyutai-labs/pocket-tts/tree/main/CONTRIBUTING.md) file. You'll also find there how to have an editable install of the package for local development.
 
 
-## Projects Using pocket-tts
+## Projects using pocket-tts
 
 - [lukasmwerner/pocket-reader](https://github.com/lukasmwerner/pocket-reader) - Browser screen reader
 


### PR DESCRIPTION
After reading #39 I wanted to showcase my quick little project [pocket-reader](https://github.com/lukasmwerner/pocket-reader) and followed the suggestion in that issue to make a section for 'Projects Using'