### PR TITLE
Implement text-to-speech audio generation

### DIFF
--- a/pocket_tts/modules/mimi_transformer.py
+++ b/pocket_tts/modules/mimi_transformer.py
@@ -75,13 +75,17 @@ class MimiStreamingMultiheadAttention(StatefulModule):
         self.out_proj = nn.Linear(embed_dim, embed_dim, bias=False)
         self.in_proj = nn.Linear(embed_dim, out_dim, bias=False)
 
-    def init_state(self, batch_size: int, sequence_length: int) -> dict[str, torch.Tensor]:
+    def init_state(
+        self, batch_size: int, sequence_length: int, device: torch.device | str = "cpu"
+    ) -> dict[str, torch.Tensor]:
         dim_per_head = self.embed_dim // self.num_heads
 
         state = {}
-        state["offset"] = torch.zeros(batch_size, dtype=torch.long)
-        state["cache"] = torch.zeros((2, batch_size, self.num_heads, sequence_length, dim_per_head))
-        state["end_offset"] = torch.zeros(batch_size, dtype=torch.long)
+        state["offset"] = torch.zeros(batch_size, dtype=torch.long, device=device)
+        state["cache"] = torch.zeros(
+            (2, batch_size, self.num_heads, sequence_length, dim_per_head), device=device
+        )
+        state["end_offset"] = torch.zeros(batch_size, dtype=torch.long, device=device)
         return state
 
     def increment_step(self, state, increment: int = 1):


### PR DESCRIPTION
The init_state() methods in StatefulModule subclasses were creating tensors without specifying a device, causing them to default to CPU even when the model was on GPU. This caused device mismatch errors during inference.

Changes:
- Add device parameter to StatefulModule.init_state() abstract method
- Update init_states() to detect device from model parameters
- Fix MimiStreamingMultiheadAttention.init_state() to use device param
- Fix StreamingConv1d.init_state() to use device param
- Fix StreamingConvTranspose1d.init_state() to use device param
- Fix StreamingMultiheadAttention.init_state() to use device param
- Fix increment_step() to create tensor directly on device