### PR TITLE
Use an environment to push to pypi

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: push_to_pypi
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
By using an environment to push to pypi, we disallow people who don't have approval rights from using it, allow us to be more flexible with the CI