### PR TITLE
fix: respect frames_after_eos parameter in generate_audio_stream()

### DIFF
--- a/pocket_tts/models/tts_model.py
+++ b/pocket_tts/models/tts_model.py
@@ -463,10 +463,13 @@ class TTSModel(nn.Module):
         for chunk in chunks:
             text_to_generate, frames_after_eos_guess = prepare_text_prompt(chunk)
             frames_after_eos_guess += 2
+            effective_frames = (
+                frames_after_eos if frames_after_eos is not None else frames_after_eos_guess
+            )
             yield from self._generate_audio_stream_short_text(
                 model_state=model_state,
                 text_to_generate=chunk,
-                frames_after_eos=frames_after_eos_guess,
+                frames_after_eos=effective_frames,
                 copy_state=copy_state,
             )
 


### PR DESCRIPTION
The `frames_after_eos` parameter in `generate_audio_stream()` and `generate_audio()` was accepted but never used - the code always used the auto-calculated guess.

**Before:** User passes `frames_after_eos=0` → ignored, uses guess (3+ frames of silence)
**After:** User passes `frames_after_eos=0` → respected, minimal trailing silence

Default behavior preserved when `frames_after_eos=None`.

I *think* this is the intention of that argument. 