### PR TITLE
Fix voice cloning from CLI

### DIFF
--- a/pocket_tts/main.py
+++ b/pocket_tts/main.py
@@ -240,7 +240,7 @@ def generate(
         )
         tts_model.to(device)
 
-        model_state_for_voice = tts_model.get_state_for_audio_prompt(voice)
+        model_state_for_voice = tts_model.get_state_for_audio_prompt(Path(voice), truncate=True)
         # Stream audio generation directly to file or stdout
         audio_chunks = tts_model.generate_audio_stream(
             model_state=model_state_for_voice,


### PR DESCRIPTION
The CLI was passing voice as a string instead of a Path object, and was missing truncate=True. This matches the working WebUI implementation.