### PR TITLE
Add OpenAI-compatible /v1/audio/speech endpoint

### DIFF
--- a/docs/serve.md
+++ b/docs/serve.md
@@ -53,6 +53,58 @@ Then, use the --config option to point to your newly created config.
 pocket-tts serve --config "C://pocket-tts/my_config.yaml"
 ```
 
+## OpenAI-Compatible Endpoint
+
+The server exposes `POST /v1/audio/speech`, a drop-in replacement for the
+[OpenAI TTS API](https://platform.openai.com/docs/api-reference/audio/createSpeech).
+Existing apps only need to change their `base_url` to point at Pocket TTS.
+
+### curl example
+
+```bash
+curl http://localhost:8000/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -d '{"model":"tts-1","input":"Hello world","voice":"alloy"}' \
+  --output speech.wav
+```
+
+### Voice mapping
+
+OpenAI voice names are mapped to Pocket TTS voices automatically.
+You can also use the native Pocket TTS names directly.
+
+| OpenAI voice | Pocket TTS voice |
+|-------------|------------------|
+| alloy       | alba             |
+| echo        | marius           |
+| fable       | javert           |
+| onyx        | jean             |
+| nova        | fantine          |
+| shimmer     | cosette          |
+| coral       | eponine          |
+| sage        | azelma           |
+
+### Using with the OpenAI Python client
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+response = client.audio.speech.create(model="tts-1", voice="alloy", input="Hello from Pocket TTS!")
+response.stream_to_file("speech.wav")
+```
+
+### Supported parameters
+
+| Parameter        | Supported | Notes                                |
+|-----------------|-----------|--------------------------------------|
+| model           | ignored   | Only one model, any value accepted   |
+| input           | yes       | Text to speak                        |
+| voice           | yes       | OpenAI or Pocket TTS name            |
+| response_format | partial   | `wav` (default) and `pcm` supported  |
+| speed           | ignored   | Accepted but has no effect           |
+
 ## Web Interface
 
 Once the server is running, navigate to `http://localhost:8000` to access the web interface.

--- a/tests/test_openai_endpoint.py
+++ b/tests/test_openai_endpoint.py
@@ -1,0 +1,71 @@
+"""Tests for the OpenAI-compatible /v1/audio/speech endpoint."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from pocket_tts.main import web_app
+from pocket_tts.models.tts_model import TTSModel
+
+import pocket_tts.main as main_module
+
+
+@pytest.fixture(scope="module")
+def client():
+    """Load the model once and expose a TestClient for the full module."""
+    model = TTSModel.load_model()
+    main_module.tts_model = model
+    main_module.global_model_state = model.get_state_for_audio_prompt("alba")
+    return TestClient(web_app)
+
+
+def _post(client, **overrides):
+    body = {"model": "tts-1", "input": "Hello.", "voice": "alloy"}
+    body.update(overrides)
+    return client.post("/v1/audio/speech", json=body)
+
+
+def test_create_speech_wav(client):
+    resp = _post(client, response_format="wav")
+    assert resp.status_code == 200
+    assert len(resp.content) > 0
+    assert resp.headers["content-type"] == "audio/wav"
+
+
+def test_create_speech_pcm(client):
+    resp = _post(client, response_format="pcm")
+    assert resp.status_code == 200
+    assert len(resp.content) > 0
+    assert resp.headers["content-type"] == "audio/pcm"
+
+
+def test_create_speech_default_format(client):
+    resp = _post(client)
+    assert resp.status_code == 200
+    assert len(resp.content) > 0
+
+
+def test_openai_voice_mapping(client):
+    for voice in ("alloy", "echo", "fable", "onyx", "nova", "shimmer", "coral", "sage"):
+        resp = _post(client, voice=voice)
+        assert resp.status_code == 200, f"voice={voice} returned {resp.status_code}"
+
+
+def test_pocket_tts_voice_names(client):
+    resp = _post(client, voice="alba")
+    assert resp.status_code == 200
+
+
+def test_invalid_voice(client):
+    resp = _post(client, voice="nonexistent_voice")
+    assert resp.status_code == 400
+
+
+def test_empty_input(client):
+    resp = _post(client, input="   ")
+    assert resp.status_code == 400
+
+
+def test_model_parameter_ignored(client):
+    for model_name in ("tts-1", "tts-1-hd", "anything-goes"):
+        resp = _post(client, model=model_name)
+        assert resp.status_code == 200, f"model={model_name} returned {resp.status_code}"


### PR DESCRIPTION
## Summary
- Add `POST /v1/audio/speech` as a drop-in replacement for the OpenAI TTS API
- Map OpenAI voice names (alloy, echo, etc.) to Pocket TTS voices
- Support `wav` (default) and `pcm` response formats
- Document the endpoint with usage examples in docs/serve.md

## Test plan
- [x] 8 new tests in `tests/test_openai_endpoint.py` — all passing
- [x] Full test suite passes (24/25, 1 pre-existing HF auth failure)
- [x] Linting passes
- [x] Manual smoke test with OpenAI Python client

🤖 Generated with [Claude Code](https://claude.com/claude-code)