### PR TITLE
Add some text normalization. convert unicode to ASCII and expand numbers into words.

### DIFF
--- a/pocket_tts/models/tts_model.py
+++ b/pocket_tts/models/tts_model.py
@@ -789,7 +789,7 @@ class TTSModel(nn.Module):
 
 def wordify_numbers(text):
     def replace_num(match):
-        raw_str = match.group()
+        raw_str = match.group().strip()
         
         # Check if it is an ordinal number (ends with st, nd, rd, or th)
         # We use a simple check on the last two characters


### PR DESCRIPTION
Add some text  normalization.
Improves overall TTS quality.

https://github.com/kyutai-labs/pocket-tts/issues/76

todo: split_into_best_sentences() can split in the middle of quoted text (characters having conversation in a book) which can ruin a flow.

partial workaround: increase max number of tokens from 50 to 100 or more.