### PR TITLE
Add basic public API tests to test_python_api.py

### DIFF
--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -1,0 +1,26 @@
+"""Tests for the public Python API surface."""
+
+import pocket_tts
+from pocket_tts import TTSModel
+from pocket_tts.models.tts_model import TTSModel as TTSModelImpl
+
+
+def test_public_api_exports_only_tts_model():
+    assert pocket_tts.__all__ == ["TTSModel"]
+
+
+def test_public_api_tts_model_points_to_implementation():
+    assert TTSModel is TTSModelImpl
+
+
+def test_public_api_expected_methods_and_properties():
+    for method_name in (
+        "load_model",
+        "generate_audio",
+        "generate_audio_stream",
+        "get_state_for_audio_prompt",
+    ):
+        assert callable(getattr(TTSModel, method_name))
+
+    for property_name in ("device", "sample_rate"):
+        assert isinstance(getattr(TTSModel, property_name), property)


### PR DESCRIPTION
## Summary
- replace tests/test_python_api.py (empty file) with concrete tests for the public Python API surface
- verify only TTSModel is exported from pocket_tts
- verify the exported TTSModel symbol points to the implementation class
- verify documented public methods/properties exist on TTSModel

## Why
AGENTS.md suggests running "uv run pytest tests/test_python_api.py -v", but the file was empty and collected 0 tests. This made the documented command misleading and left the public API surface untested.

## Validation
- uv run pytest tests/test_python_api.py -v
  - 3 passed
