### PR TITLE
Add PocketTTS.cpp to alternative implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ We don't have official support for this yet, but you can try out one of these co
 - [pocket-tts-mlx](https://github.com/jishnuvenugopal/pocket-tts-mlx) by @jishnuvenugopal - MLX backend optimized for Apple Silicon
 - [pocket-tts-xn](https://github.com/LaurentMazare/xn/tree/main/pocket-tts) by @LaurentMazare - A Rust port of Pocket TTS implemented with XN.
 - [pocket-tts-candle](https://github.com/babybirdprd/pocket-tts) by @babybirdprd - Candle version (Rust) with WebAssembly and PyO3 bindings.
+- [PocketTTS.cpp](https://github.com/VolgaGerm/PocketTTS.cpp) by @VolgaGerm - Single-file C++ runtime using ONNX Runtime, with CLI, HTTP server, and FFI C API.
 
 ## Projects using Pocket TTS
 


### PR DESCRIPTION
Adds PocketTTS.cpp to the alternative implementations list — a C++ ONNX Runtime port with CLI, streaming HTTP server, and a C API for FFI.