### PR TITLE
Add OpenClaw integrations to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ We don't have official support for this yet, but you can try out one of these co
 - [cursed-codex](https://github.com/dooart/cursed-codex) by @dooart - AI coding agent with unhinged live football commentary
 - [pocket-tts-deno](https://github.com/ohmstone/pocket-tts-deno) Port of [pocket-tts-server](https://github.com/ai-joe-git/pocket-tts-server) as a wasm + onnx deno server with voice TTS API.
 - [FrontPocket](https://github.com/markd89/FrontPocket) by @markd89 - Front-end for Pocket-TTS to speak text from clipboard, file, CLI (hotkeys) & GUI toolbar. Change playback speed, voice, and move forward/backward between sentences instantaneously. 
+- [openclaw-pockettts](https://github.com/dodgyrabbit/openclaw-pockettts) by @dodgyrabbit - A Docker container with the Python implementation but exposed as an OpenAI TTS API for easy integration with OpenClaw.
+- [openclaw-pocketts.cpp](https://github.com/dodgyrabbit/openclaw-pockettts.cpp) by @dodgyrabbit - A Docker container with the PocketTTS.cpp version, packaged for easy integration with OpenClaw.
 
 
 ## Prohibited use


### PR DESCRIPTION
I created two projects, that both make it easy to use PocketTTS with OpenClaw.

The Python version simply exposes the API as the OpenAI variant. Instructions on how to wire up OpenClaw.
The CPP version wraps the cool implementation that was done in Docker. It already exposes an OpenAI endpoint. Again, instructions on how to wire up OpenClaw.
