### PR TITLE
fix: rewrite decimals before splitting to avoid spurious sentence boundaries

### DIFF
--- a/pocket_tts/models/tts_model.py
+++ b/pocket_tts/models/tts_model.py
@@ -3,6 +3,7 @@ import logging
 import math
 import os
 import queue
+import re
 import statistics
 import threading
 import time
@@ -975,6 +976,22 @@ def _segments_from_boundaries(
     return segments
 
 
+_DECIMAL_RE = re.compile(r"(\d+)\.(\d+)")
+
+
+def _normalize_decimals(text: str) -> str:
+    """Replace decimal numbers with spoken form to avoid spurious sentence splits.
+
+    The sentence splitter treats every period token as a potential boundary.
+    Decimals like '98.6' therefore get incorrectly split into '98.' and '6…',
+    producing broken audio output.  Rewriting to '98 point 6' before tokenisation
+    removes the period from the token stream so the splitter never sees it.
+
+    Only digit·period·digit patterns are rewritten; prose punctuation is untouched.
+    """
+    return _DECIMAL_RE.sub(r"\1 point \2", text)
+
+
 def split_into_best_sentences(
     tokenizer,
     text_to_generate: str,
@@ -985,6 +1002,7 @@ def split_into_best_sentences(
     text_to_generate, _ = prepare_text_prompt(
         text_to_generate, pad_with_spaces_for_short_inputs, remove_semicolons
     )
+    text_to_generate = _normalize_decimals(text_to_generate)
     text_to_generate = text_to_generate.strip()
     tokens = tokenizer(text_to_generate)
     list_of_tokens = tokens.tokens[0].tolist()

--- a/pocket_tts/models/tts_model.py
+++ b/pocket_tts/models/tts_model.py
@@ -977,44 +977,108 @@ def _segments_from_boundaries(
     return segments
 
 
-_DECIMAL_RE = re.compile(r"(\d+)\.(\d+)")
+# Patterns for "atoms" — substrings that contain split-relevant punctuation
+# but should never be treated as sentence boundaries (decimals, URLs, emails,
+# honorifics, common abbreviations).  Order matters in :func:`_atom_patterns_for`:
+# email comes before URL so the URL pattern doesn't consume the domain part of
+# an email; URL comes before the digit pattern so IP-like labels in URLs are
+# captured as one atom.
+_EMAIL_RE = re.compile(r"\b[\w.+-]+@[\w-]+(?:\.[\w-]+)+\b")
+_URL_RE = re.compile(r"\b(?:https?://)?(?:[\w-]+\.)+[a-zA-Z]{2,}(?:/\S*)?")
+# Number with an internal '.' or ',' separator: decimals (98.6, 37,0) and
+# thousands separators (1,000, 1.000) in any locale.
+_DIGIT_NUMBER_RE = re.compile(r"\d+(?:[.,]\d+)+")
 
-# Spoken form of the decimal point for each supported language config stem.
-# Languages not listed here fall back to "point".
-_DECIMAL_WORD: dict[str, str] = {
-    "english": "point",
-    "french": "virgule",
-    "french_24l": "virgule",
-    "german": "Komma",
-    "german_24l": "Komma",
-    "spanish": "coma",
-    "spanish_24l": "coma",
-    "portuguese": "vírgula",
-    "portuguese_24l": "vírgula",
-    "italian": "virgola",
-    "italian_24l": "virgola",
+# Per-language honorifics and common abbreviations.  Keys use the base language
+# name; "_24l" variants are stripped before lookup in :func:`_atom_patterns_for`.
+_HONORIFICS: dict[str, list[str]] = {
+    "english": [
+        r"\bMr\.",
+        r"\bMrs\.",
+        r"\bMs\.",
+        r"\bDr\.",
+        r"\bProf\.",
+        r"\bSr\.",
+        r"\bJr\.",
+        r"\bSt\.",
+        r"\bRev\.",
+    ],
+    "french": [r"\bMme\.", r"\bMlle\.", r"\bDr\.", r"\bPr\.", r"\bM\."],
+    "german": [r"\bHr\.", r"\bFr\.", r"\bDr\.", r"\bProf\."],
+    "spanish": [r"\bSra\.", r"\bSrta\.", r"\bDra\.", r"\bSr\.", r"\bDr\.", r"\bProf\."],
+    "italian": [r"\bDott\.", r"\bSig\.", r"\bDr\.", r"\bProf\."],
+    "portuguese": [r"\bSra\.", r"\bSrta\.", r"\bDra\.", r"\bSr\.", r"\bDr\.", r"\bProf\."],
+}
+
+_ABBREVIATIONS: dict[str, list[str]] = {
+    "english": [r"\be\.g\.", r"\bi\.e\.", r"\betc\.", r"\bvs\."],
+    "french": [r"\bp\.ex\.", r"\bex\."],
+    "german": [r"\bz\.B\.", r"\bbzw\.", r"\busw\.", r"\bd\.h\."],
 }
 
 
-def _normalize_decimals(text: str, language: str = "english") -> str:
-    """Replace decimal numbers with their spoken form to avoid spurious sentence splits.
+def _atom_patterns_for(language: str) -> list[re.Pattern]:
+    """Return the ordered list of atom patterns to apply for ``language``.
 
-    The sentence splitter treats every period token as a potential boundary.
-    Decimals like '98.6' therefore get incorrectly split into '98.' and '6…',
-    producing broken audio output.  Rewriting to the appropriate spoken form
-    (e.g. '98 point 6' in English, '98 Komma 6' in German) before tokenisation
-    removes the period from the token stream so the splitter never sees it.
+    Patterns are returned in priority order: more specific patterns (email,
+    URL) come first so that broader patterns can't consume parts of them.
+    Per-language honorifics and abbreviations are appended after the
+    language-agnostic patterns.
+    """
+    base_lang = language.removesuffix("_24l") if language else "english"
+    patterns: list[re.Pattern] = [_EMAIL_RE, _URL_RE, _DIGIT_NUMBER_RE]
+    for source in (_HONORIFICS, _ABBREVIATIONS):
+        patterns.extend(re.compile(p) for p in source.get(base_lang, []))
+    return patterns
 
-    Only digit·period·digit patterns are rewritten; prose punctuation is untouched.
+
+def _make_placeholder(index: int) -> str:
+    """Build a unique letter-only placeholder for the ``index``-th atom.
+
+    Letter-only guarantees the placeholder contains no character the splitter
+    treats as a boundary, so it survives sentence splitting as a single opaque
+    token sequence.
+    """
+    return f"AaaaAtomAaaa{index:04d}Zzzz"
+
+
+def _protect_atoms(text: str, language: str = "english") -> tuple[str, dict[str, str]]:
+    """Replace splitter-confusing substrings with opaque placeholders.
+
+    The sentence splitter treats every period, comma, semicolon, and colon
+    token as a potential boundary.  That breaks decimals (``98.6``, ``37,0``),
+    honorifics (``Dr. Smith``), URLs (``example.com``), emails, and similar
+    atomic substrings that contain those characters internally.  This function
+    finds such atoms and replaces each with a placeholder containing no
+    boundary characters, so the splitter sees them as opaque words.  Restore
+    the originals in each output chunk via :func:`_restore_atoms`.
 
     Args:
-        text: The input text to normalise.
-        language: Language config stem (e.g. ``"english"``, ``"german"``).
-            Controls the spoken word used for the decimal separator.
-            Defaults to ``"english"`` (spoken form: ``"point"``).
+        text: The input text to scan.
+        language: Language config stem (e.g. ``"english"``, ``"german_24l"``).
+            Controls which honorifics and abbreviations are recognised.
+
+    Returns:
+        A pair ``(modified_text, atoms)`` where ``atoms`` maps each
+        placeholder back to the original substring it replaced.
     """
-    word = _DECIMAL_WORD.get(language, "point")
-    return _DECIMAL_RE.sub(rf"\1 {word} \2", text)
+    atoms: dict[str, str] = {}
+    for pattern in _atom_patterns_for(language):
+
+        def replace(match: re.Match) -> str:
+            placeholder = _make_placeholder(len(atoms))
+            atoms[placeholder] = match.group(0)
+            return placeholder
+
+        text = pattern.sub(replace, text)
+    return text, atoms
+
+
+def _restore_atoms(text: str, atoms: dict[str, str]) -> str:
+    """Restore original substrings replaced by :func:`_protect_atoms`."""
+    for placeholder, original in atoms.items():
+        text = text.replace(placeholder, original)
+    return text
 
 
 def split_into_best_sentences(
@@ -1028,8 +1092,11 @@ def split_into_best_sentences(
     text_to_generate, _ = prepare_text_prompt(
         text_to_generate, pad_with_spaces_for_short_inputs, remove_semicolons
     )
-    text_to_generate = _normalize_decimals(text_to_generate, language=language)
     text_to_generate = text_to_generate.strip()
+    # Mask atoms (decimals, URLs, emails, honorifics, abbreviations) so the
+    # splitter doesn't break them on internal punctuation.  Originals are
+    # restored in each chunk before returning.
+    text_to_generate, atoms = _protect_atoms(text_to_generate, language=language)
     tokens = tokenizer(text_to_generate)
     list_of_tokens = tokens.tokens[0].tolist()
 
@@ -1074,6 +1141,8 @@ def split_into_best_sentences(
 
     if current_chunk != "":
         chunks.append(current_chunk.strip())
+
+    chunks = [_restore_atoms(chunk, atoms) for chunk in chunks]
 
     for chunk in chunks:
         chunk_tokens = tokenizer(chunk.strip()).tokens[0].tolist()

--- a/pocket_tts/models/tts_model.py
+++ b/pocket_tts/models/tts_model.py
@@ -614,6 +614,7 @@ class TTSModel(nn.Module):
             max_tokens,
             self.pad_with_spaces_for_short_inputs,
             remove_semicolons=self.remove_semicolons,
+            language=self.origin.stem if self.origin is not None else "english",
         )
 
         for chunk in chunks:
@@ -978,18 +979,42 @@ def _segments_from_boundaries(
 
 _DECIMAL_RE = re.compile(r"(\d+)\.(\d+)")
 
+# Spoken form of the decimal point for each supported language config stem.
+# Languages not listed here fall back to "point".
+_DECIMAL_WORD: dict[str, str] = {
+    "english": "point",
+    "french": "virgule",
+    "french_24l": "virgule",
+    "german": "Komma",
+    "german_24l": "Komma",
+    "spanish": "coma",
+    "spanish_24l": "coma",
+    "portuguese": "vírgula",
+    "portuguese_24l": "vírgula",
+    "italian": "virgola",
+    "italian_24l": "virgola",
+}
 
-def _normalize_decimals(text: str) -> str:
-    """Replace decimal numbers with spoken form to avoid spurious sentence splits.
+
+def _normalize_decimals(text: str, language: str = "english") -> str:
+    """Replace decimal numbers with their spoken form to avoid spurious sentence splits.
 
     The sentence splitter treats every period token as a potential boundary.
     Decimals like '98.6' therefore get incorrectly split into '98.' and '6…',
-    producing broken audio output.  Rewriting to '98 point 6' before tokenisation
+    producing broken audio output.  Rewriting to the appropriate spoken form
+    (e.g. '98 point 6' in English, '98 Komma 6' in German) before tokenisation
     removes the period from the token stream so the splitter never sees it.
 
     Only digit·period·digit patterns are rewritten; prose punctuation is untouched.
+
+    Args:
+        text: The input text to normalise.
+        language: Language config stem (e.g. ``"english"``, ``"german"``).
+            Controls the spoken word used for the decimal separator.
+            Defaults to ``"english"`` (spoken form: ``"point"``).
     """
-    return _DECIMAL_RE.sub(r"\1 point \2", text)
+    word = _DECIMAL_WORD.get(language, "point")
+    return _DECIMAL_RE.sub(rf"\1 {word} \2", text)
 
 
 def split_into_best_sentences(
@@ -998,11 +1023,12 @@ def split_into_best_sentences(
     max_tokens: int,
     pad_with_spaces_for_short_inputs: bool,
     remove_semicolons: bool,
+    language: str = "english",
 ) -> list[str]:
     text_to_generate, _ = prepare_text_prompt(
         text_to_generate, pad_with_spaces_for_short_inputs, remove_semicolons
     )
-    text_to_generate = _normalize_decimals(text_to_generate)
+    text_to_generate = _normalize_decimals(text_to_generate, language=language)
     text_to_generate = text_to_generate.strip()
     tokens = tokenizer(text_to_generate)
     list_of_tokens = tokens.tokens[0].tolist()

--- a/tests/test_split_sentences.py
+++ b/tests/test_split_sentences.py
@@ -3,7 +3,7 @@
 import pytest
 
 from pocket_tts.conditioners.text import get_default_tokenizer
-from pocket_tts.models.tts_model import split_into_best_sentences
+from pocket_tts.models.tts_model import _normalize_decimals, split_into_best_sentences
 
 
 @pytest.fixture(scope="session")
@@ -118,6 +118,71 @@ def test_short_sentence_not_affected_by_comma_splitting(tokenizer):
     assert len(chunks) == 1
     assert "hello" in chunks[0].lower()
     assert "world" in chunks[0].lower()
+
+
+class TestNormalizeDecimals:
+    """Unit tests for _normalize_decimals (issue #162)."""
+
+    def test_simple_decimal(self):
+        assert _normalize_decimals("98.6") == "98 point 6"
+
+    def test_pi(self):
+        assert _normalize_decimals("Pi is 3.14") == "Pi is 3 point 14"
+
+    def test_multiple_decimals(self):
+        assert _normalize_decimals("Pi is 3.14 and e is 2.718.") == (
+            "Pi is 3 point 14 and e is 2 point 718."
+        )
+
+    def test_prose_period_untouched(self):
+        """A period at end of a sentence (not between digits) must not be changed."""
+        assert _normalize_decimals("Hello world.") == "Hello world."
+
+    def test_no_decimals_unchanged(self):
+        assert _normalize_decimals("No numbers here at all.") == "No numbers here at all."
+
+    def test_integer_period_not_matched(self):
+        """A period following digits but not followed by digits is untouched."""
+        assert _normalize_decimals("See section 4. It is important.") == (
+            "See section 4. It is important."
+        )
+
+
+def test_decimal_not_split_into_separate_chunks(tokenizer):
+    """Decimals must not be treated as sentence boundaries (issue #162).
+
+    '98.6°F' was previously split into ['98.', '6°F…'] because the period
+    token matched the sentence-boundary set.  After normalisation the decimal
+    is rewritten to '98 point 6' before tokenisation, so the chunk is kept
+    whole.
+    """
+    text = "The average human body temperature is 98.6°F, which is normal."
+    chunks = split_into_best_sentences(
+        tokenizer,
+        text,
+        max_tokens=50,
+        pad_with_spaces_for_short_inputs=False,
+        remove_semicolons=False,
+    )
+    # The whole sentence fits in 50 tokens — must be a single chunk.
+    assert len(chunks) == 1
+    # The decimal value must survive intact (rewritten form expected).
+    assert "point" in chunks[0].lower()
+
+
+def test_multiple_decimals_preserved(tokenizer):
+    """Multiple decimals in one sentence are all normalised correctly."""
+    text = "Pi is 3.14 and e is 2.718."
+    chunks = split_into_best_sentences(
+        tokenizer,
+        text,
+        max_tokens=50,
+        pad_with_spaces_for_short_inputs=False,
+        remove_semicolons=False,
+    )
+    assert len(chunks) == 1
+    rejoined = chunks[0].lower()
+    assert "3 point 14" in rejoined or "point" in rejoined
 
 
 def test_empty_string_raises(tokenizer):

--- a/tests/test_split_sentences.py
+++ b/tests/test_split_sentences.py
@@ -3,7 +3,11 @@
 import pytest
 
 from pocket_tts.conditioners.text import get_default_tokenizer
-from pocket_tts.models.tts_model import _normalize_decimals, split_into_best_sentences
+from pocket_tts.models.tts_model import (
+    _DECIMAL_WORD,
+    _normalize_decimals,
+    split_into_best_sentences,
+)
 
 
 @pytest.fixture(scope="session")
@@ -146,6 +150,44 @@ class TestNormalizeDecimals:
         assert _normalize_decimals("See section 4. It is important.") == (
             "See section 4. It is important."
         )
+
+    def test_german_uses_komma(self):
+        assert _normalize_decimals("37.0°C", language="german") == "37 Komma 0°C"
+
+    def test_french_uses_virgule(self):
+        assert _normalize_decimals("3.14", language="french") == "3 virgule 14"
+
+    def test_french_24l_uses_virgule(self):
+        assert _normalize_decimals("3.14", language="french_24l") == "3 virgule 14"
+
+    def test_spanish_uses_coma(self):
+        assert _normalize_decimals("2.5", language="spanish") == "2 coma 5"
+
+    def test_portuguese_uses_virgula(self):
+        assert _normalize_decimals("1.5", language="portuguese") == "1 vírgula 5"
+
+    def test_italian_uses_virgola(self):
+        assert _normalize_decimals("9.8", language="italian") == "9 virgola 8"
+
+    def test_unknown_language_falls_back_to_point(self):
+        assert _normalize_decimals("3.14", language="klingon") == "3 point 14"
+
+    def test_all_supported_languages_have_mapping(self):
+        """Every language config that pocket-tts ships must have an entry in _DECIMAL_WORD."""
+        expected = {
+            "english",
+            "french",
+            "french_24l",
+            "german",
+            "german_24l",
+            "spanish",
+            "spanish_24l",
+            "portuguese",
+            "portuguese_24l",
+            "italian",
+            "italian_24l",
+        }
+        assert expected == set(_DECIMAL_WORD.keys())
 
 
 def test_decimal_not_split_into_separate_chunks(tokenizer):

--- a/tests/test_split_sentences.py
+++ b/tests/test_split_sentences.py
@@ -3,11 +3,7 @@
 import pytest
 
 from pocket_tts.conditioners.text import get_default_tokenizer
-from pocket_tts.models.tts_model import (
-    _DECIMAL_WORD,
-    _normalize_decimals,
-    split_into_best_sentences,
-)
+from pocket_tts.models.tts_model import _protect_atoms, _restore_atoms, split_into_best_sentences
 
 
 @pytest.fixture(scope="session")
@@ -124,79 +120,174 @@ def test_short_sentence_not_affected_by_comma_splitting(tokenizer):
     assert "world" in chunks[0].lower()
 
 
-class TestNormalizeDecimals:
-    """Unit tests for _normalize_decimals (issue #162)."""
+class TestProtectAtoms:
+    """Unit tests for _protect_atoms / _restore_atoms (issue #162 + follow-up)."""
 
-    def test_simple_decimal(self):
-        assert _normalize_decimals("98.6") == "98 point 6"
+    # ---- decimals: period and comma forms ----
 
-    def test_pi(self):
-        assert _normalize_decimals("Pi is 3.14") == "Pi is 3 point 14"
+    def test_decimal_period_replaced(self):
+        protected, atoms = _protect_atoms("98.6")
+        assert "98.6" not in protected
+        assert "98.6" in atoms.values()
+        assert _restore_atoms(protected, atoms) == "98.6"
 
-    def test_multiple_decimals(self):
-        assert _normalize_decimals("Pi is 3.14 and e is 2.718.") == (
-            "Pi is 3 point 14 and e is 2 point 718."
-        )
+    def test_decimal_comma_replaced(self):
+        # German-style decimal — protected regardless of language because the
+        # splitter treats commas as fallback boundaries in every language.
+        protected, atoms = _protect_atoms("37,0")
+        assert "37,0" not in protected
+        assert "37,0" in atoms.values()
+        assert _restore_atoms(protected, atoms) == "37,0"
+
+    def test_thousands_separator_replaced(self):
+        # Both English-style ("1,000") and German-style ("1.000") thousands
+        # must be opaque so the splitter doesn't break them apart.
+        for raw in ("1,000", "1.000", "1,000.50", "1.000,50"):
+            protected, atoms = _protect_atoms(raw)
+            assert raw not in protected, f"{raw!r} should be replaced"
+            assert _restore_atoms(protected, atoms) == raw
 
     def test_prose_period_untouched(self):
-        """A period at end of a sentence (not between digits) must not be changed."""
-        assert _normalize_decimals("Hello world.") == "Hello world."
+        protected, atoms = _protect_atoms("Hello world.")
+        assert protected == "Hello world."
+        assert atoms == {}
 
-    def test_no_decimals_unchanged(self):
-        assert _normalize_decimals("No numbers here at all.") == "No numbers here at all."
+    def test_prose_comma_untouched(self):
+        protected, atoms = _protect_atoms("Hello, world.")
+        assert protected == "Hello, world."
+        assert atoms == {}
 
-    def test_integer_period_not_matched(self):
-        """A period following digits but not followed by digits is untouched."""
-        assert _normalize_decimals("See section 4. It is important.") == (
-            "See section 4. It is important."
+    def test_integer_period_untouched(self):
+        # "Section 4." has a period after a digit but no digit after.
+        # Must remain a sentence boundary.
+        protected, atoms = _protect_atoms("See section 4. It is important.")
+        assert protected == "See section 4. It is important."
+
+    # ---- URLs ----
+
+    def test_url_with_scheme_replaced(self):
+        text = "Visit https://example.com today"
+        protected, atoms = _protect_atoms(text)
+        assert "https://example.com" not in protected
+        assert _restore_atoms(protected, atoms) == text
+
+    def test_url_without_scheme_replaced(self):
+        text = "Visit example.com today"
+        protected, atoms = _protect_atoms(text)
+        assert "example.com" not in protected
+        assert _restore_atoms(protected, atoms) == text
+
+    def test_subdomain_url_replaced(self):
+        text = "See docs.python.org for help"
+        protected, atoms = _protect_atoms(text)
+        assert "docs.python.org" not in protected
+        assert _restore_atoms(protected, atoms) == text
+
+    # ---- emails ----
+
+    def test_email_replaced(self):
+        text = "Email me at alice@example.com please"
+        protected, atoms = _protect_atoms(text)
+        assert "alice@example.com" not in protected
+        assert _restore_atoms(protected, atoms) == text
+
+    def test_email_takes_precedence_over_url(self):
+        # The URL pattern would otherwise match example.com inside the email.
+        # Email must be detected first so the whole address becomes one atom.
+        text = "alice@example.com"
+        protected, atoms = _protect_atoms(text)
+        assert text in atoms.values()
+        assert len(atoms) == 1
+
+    # ---- honorifics (per language) ----
+
+    def test_english_honorific_replaced(self):
+        text = "Dr. Smith arrived at noon."
+        protected, atoms = _protect_atoms(text, language="english")
+        assert "Dr." not in protected
+        assert "Dr." in atoms.values()
+        assert _restore_atoms(protected, atoms) == text
+
+    def test_german_honorific_replaced(self):
+        text = "Hr. Schmidt kam um zwölf."
+        protected, atoms = _protect_atoms(text, language="german")
+        assert "Hr." not in protected
+        assert _restore_atoms(protected, atoms) == text
+
+    def test_french_honorific_replaced(self):
+        text = "M. Dupont est arrivé."
+        protected, atoms = _protect_atoms(text, language="french")
+        assert "M." not in protected
+        assert _restore_atoms(protected, atoms) == text
+
+    def test_24l_variant_uses_base_language_honorifics(self):
+        text = "Dr. Smith arrived."
+        protected, _ = _protect_atoms(text, language="english_24l")
+        assert "Dr." not in protected
+
+    # ---- abbreviations (per language) ----
+
+    def test_english_abbreviation_replaced(self):
+        text = "Apples, e.g. Granny Smith, are tasty."
+        protected, atoms = _protect_atoms(text, language="english")
+        assert "e.g." not in protected
+        assert "e.g." in atoms.values()
+        assert _restore_atoms(protected, atoms) == text
+
+    def test_german_abbreviation_replaced(self):
+        text = "Obst, z.B. Äpfel, schmecken gut."
+        protected, _ = _protect_atoms(text, language="german")
+        assert "z.B." not in protected
+
+    # ---- multiple atoms in one text ----
+
+    def test_multiple_atoms_all_protected_and_restored(self):
+        text = (
+            "Dr. Smith said it's 98.6°F at 3.14 PM, "
+            "see https://example.com or email alice@example.com for details."
         )
+        protected, atoms = _protect_atoms(text, language="english")
+        assert "Dr." not in protected
+        assert "98.6" not in protected
+        assert "3.14" not in protected
+        assert "https://example.com" not in protected
+        assert "alice@example.com" not in protected
+        assert _restore_atoms(protected, atoms) == text
 
-    def test_german_uses_komma(self):
-        assert _normalize_decimals("37.0°C", language="german") == "37 Komma 0°C"
+    # ---- placeholders are safe for the splitter ----
 
-    def test_french_uses_virgule(self):
-        assert _normalize_decimals("3.14", language="french") == "3 virgule 14"
+    def test_placeholders_contain_no_boundary_chars(self):
+        text = "Dr. Smith says it's 98.6°F, see example.com."
+        _, atoms = _protect_atoms(text, language="english")
+        for placeholder in atoms:
+            for ch in ".,;:!?":
+                assert ch not in placeholder, (
+                    f"Placeholder {placeholder!r} must not contain boundary char {ch!r}"
+                )
 
-    def test_french_24l_uses_virgule(self):
-        assert _normalize_decimals("3.14", language="french_24l") == "3 virgule 14"
+    # ---- empty / no-op cases ----
 
-    def test_spanish_uses_coma(self):
-        assert _normalize_decimals("2.5", language="spanish") == "2 coma 5"
+    def test_empty_text_returns_empty(self):
+        protected, atoms = _protect_atoms("")
+        assert protected == ""
+        assert atoms == {}
 
-    def test_portuguese_uses_virgula(self):
-        assert _normalize_decimals("1.5", language="portuguese") == "1 vírgula 5"
+    def test_text_with_no_atoms(self):
+        text = "Just regular words here."
+        protected, atoms = _protect_atoms(text)
+        assert protected == text
+        assert atoms == {}
 
-    def test_italian_uses_virgola(self):
-        assert _normalize_decimals("9.8", language="italian") == "9 virgola 8"
-
-    def test_unknown_language_falls_back_to_point(self):
-        assert _normalize_decimals("3.14", language="klingon") == "3 point 14"
-
-    def test_all_supported_languages_have_mapping(self):
-        """Every language config that pocket-tts ships must have an entry in _DECIMAL_WORD."""
-        expected = {
-            "english",
-            "french",
-            "french_24l",
-            "german",
-            "german_24l",
-            "spanish",
-            "spanish_24l",
-            "portuguese",
-            "portuguese_24l",
-            "italian",
-            "italian_24l",
-        }
-        assert expected == set(_DECIMAL_WORD.keys())
+    def test_restore_handles_no_atoms(self):
+        assert _restore_atoms("Just regular text.", {}) == "Just regular text."
 
 
 def test_decimal_not_split_into_separate_chunks(tokenizer):
     """Decimals must not be treated as sentence boundaries (issue #162).
 
-    '98.6°F' was previously split into ['98.', '6°F…'] because the period
-    token matched the sentence-boundary set.  After normalisation the decimal
-    is rewritten to '98 point 6' before tokenisation, so the chunk is kept
-    whole.
+    The mask-based splitter wraps decimals in placeholders that contain no
+    boundary characters, runs the splitter, then restores the originals.
+    The decimal is preserved literally in the output chunk.
     """
     text = "The average human body temperature is 98.6°F, which is normal."
     chunks = split_into_best_sentences(
@@ -206,14 +297,87 @@ def test_decimal_not_split_into_separate_chunks(tokenizer):
         pad_with_spaces_for_short_inputs=False,
         remove_semicolons=False,
     )
-    # The whole sentence fits in 50 tokens — must be a single chunk.
     assert len(chunks) == 1
-    # The decimal value must survive intact (rewritten form expected).
-    assert "point" in chunks[0].lower()
+    assert "98.6" in chunks[0]
+
+
+def test_german_decimal_comma_not_split(tokenizer):
+    """German decimal-comma (memchr's case) must survive splitting in long sentences."""
+    text = (
+        "Die durchschnittliche Körpertemperatur eines erwachsenen Menschen "
+        "beträgt 37,0 Grad Celsius, was als normal angesehen wird, "
+        "während eine Temperatur von 38,5 Grad bereits als Fieber gilt, "
+        "und eine Temperatur über 40,0 Grad ist gefährlich."
+    )
+    chunks = split_into_best_sentences(
+        tokenizer,
+        text,
+        max_tokens=30,
+        pad_with_spaces_for_short_inputs=False,
+        remove_semicolons=False,
+        language="german",
+    )
+    rejoined = " ".join(chunks)
+    assert "37,0" in rejoined
+    assert "38,5" in rejoined
+    assert "40,0" in rejoined
+    # No chunk fragments a decimal across a boundary.
+    for chunk in chunks:
+        assert not chunk.rstrip().endswith(("37,", "38,", "40,"))
+
+
+def test_honorific_not_split(tokenizer):
+    """A sentence with 'Dr.' must not be split between the honorific and the name."""
+    text = "Dr. Smith and Dr. Jones discussed the patient. They agreed on the diagnosis."
+    chunks = split_into_best_sentences(
+        tokenizer,
+        text,
+        max_tokens=15,
+        pad_with_spaces_for_short_inputs=False,
+        remove_semicolons=False,
+    )
+    for chunk in chunks:
+        assert not chunk.rstrip().endswith("Dr.")
+
+
+def test_url_not_split(tokenizer):
+    """A URL with internal dots must not be split inside the domain."""
+    text = "Please visit https://example.com for more information about the product."
+    chunks = split_into_best_sentences(
+        tokenizer,
+        text,
+        max_tokens=50,
+        pad_with_spaces_for_short_inputs=False,
+        remove_semicolons=False,
+    )
+    rejoined = " ".join(chunks)
+    assert "https://example.com" in rejoined
+
+
+def test_english_thousands_not_split(tokenizer):
+    """English '1,000' (thousands separator) must not be split in long sentences."""
+    text = (
+        "The crowd of 1,000 people gathered at the square, "
+        "the police estimated 2,500 attendees, "
+        "while the organizers claimed 5,000 supporters showed up."
+    )
+    chunks = split_into_best_sentences(
+        tokenizer,
+        text,
+        max_tokens=20,
+        pad_with_spaces_for_short_inputs=False,
+        remove_semicolons=False,
+    )
+    rejoined = " ".join(chunks)
+    assert "1,000" in rejoined
+    assert "2,500" in rejoined
+    assert "5,000" in rejoined
+    for chunk in chunks:
+        assert not chunk.rstrip().endswith(("1,", "2,", "5,"))
 
 
 def test_multiple_decimals_preserved(tokenizer):
-    """Multiple decimals in one sentence are all normalised correctly."""
+    """Multiple decimals in one sentence are all preserved literally."""
     text = "Pi is 3.14 and e is 2.718."
     chunks = split_into_best_sentences(
         tokenizer,
@@ -223,8 +387,8 @@ def test_multiple_decimals_preserved(tokenizer):
         remove_semicolons=False,
     )
     assert len(chunks) == 1
-    rejoined = chunks[0].lower()
-    assert "3 point 14" in rejoined or "point" in rejoined
+    assert "3.14" in chunks[0]
+    assert "2.718" in chunks[0]
 
 
 def test_empty_string_raises(tokenizer):


### PR DESCRIPTION
Fixes #162

## What was wrong

The sentence splitter in `split_into_best_sentences` builds its boundary token set by tokenising `.!...?` and then marks every matching period token as a split point. Decimal numbers like `98.6` contain a period that tokenises identically to a sentence-ending period, so the splitter incorrectly breaks them across chunk boundaries:

```
"The average human body temperature is 98.6°F, which is normal."
→ ["98.", "6°F, which is normal."]
```

This produces broken/mangled audio output for any text containing decimals.

## Fix

Add `_normalize_decimals()` which rewrites `digit.digit` patterns to spoken form before tokenisation:

- `98.6` → `98 point 6`
- `3.14` → `3 point 14`
- `2.718` → `2 point 718`

The rewritten form contains no period, so the splitter never sees it as a boundary. Prose punctuation (sentence-ending periods, ellipses, etc.) is not affected — only digit·period·digit patterns match.

This follows the direction suggested by @gabrieldemarmiesse in the issue: use a text normalisation step rather than trying to patch the splitter's boundary detection logic.

## Notes

- No new dependencies — pure `re` from the standard library
- The fix is applied once at the start of `split_into_best_sentences`, before the first tokenisation pass
- Broader number normalisation (e.g. large integers, currency) is left as a follow-on; this PR is intentionally narrow

## Tests

Added to `tests/test_split_sentences.py`:

- `TestNormalizeDecimals` — 6 unit tests covering simple decimals, multiple decimals, prose periods left untouched, integers with trailing periods untouched
- `test_decimal_not_split_into_separate_chunks` — integration test using the tokenizer fixture: the exact example from #162 (`98.6°F`) must not be split
- `test_multiple_decimals_preserved` — multiple decimals in one sentence all normalised

All 8 new tests pass locally alongside the existing suite.