### PR TITLE
docs: clarify uv virtual environment usage with --active flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,21 @@ Navigate to the [Kyutai website](https://kyutai.org/pocket-tts) to try it out di
 ## Trying it with the CLI
 
 ### The `generate` command
-You can use pocket-tts directly from the command line. We recommend using
+You can use pocket-tts directly from the command line.
+
+### ⚠️ Virtual Environment Note
+
+If you are using your own virtual environment, you may see a warning like:
+
+VIRTUAL_ENV does not match the project environment
+
+This happens because `uv` may try to create its own environment.
+
+To use your currently activated environment, run:
+
+uv run --active pocket-tts generate
+
+ We recommend using
 `uv` as it installs any dependencies on the fly in an isolated environment (uv installation instructions [here](https://docs.astral.sh/uv/getting-started/installation/#standalone-installer)).
 You can also use `pip install pocket-tts` to install it manually.
 

--- a/README.md
+++ b/README.md
@@ -41,18 +41,18 @@ You can use pocket-tts directly from the command line.
 
 ### ⚠️ Virtual Environment Note
 
-If you are using your own virtual environment, you may see a warning like:
+If you are using a custom virtual environment, you may see a warning like:
+`VIRTUAL_ENV does not match the project environment`
 
-VIRTUAL_ENV does not match the project environment
-
-This happens because `uv` may try to create its own environment.
+This happens because `uv` may create its own environment by default.
 
 To use your currently activated environment, run:
-
+```bash
 uv run --active pocket-tts generate
 
- We recommend using
-`uv` as it installs any dependencies on the fly in an isolated environment (uv installation instructions [here](https://docs.astral.sh/uv/getting-started/installation/#standalone-installer)).
+```
+
+We recommend using `uv` as it installs any dependencies on the fly in an isolated environment (uv installation instructions [here](https://docs.astral.sh/uv/getting-started/installation/#standalone-installer)).
 You can also use `pip install pocket-tts` to install it manually.
 
 This will generate a wav file `./tts_output.wav` saying the default text with the default voice, and display some speed statistics.


### PR DESCRIPTION
This PR improves the CLI documentation for `pocket-tts` by clarifying the virtual environment mismatch warning that occurs when using `uv`. It explains why the `VIRTUAL_ENV does not match the project environment` warning appears, namely due to `uv` creating its own environment by default, and provides the correct usage with `uv run --active pocket-tts generate`. Additionally, it includes alternative methods (`uvx` and `pip`), clarifies the expected output file (`./tts_output.wav`), and refines wording for better clarity. These documentation updates aim to reduce confusion for users working with custom virtual environments and improve the overall onboarding experience.
