### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -28,7 +28,7 @@ Quantization works out of the box on any supported PyTorch version (2.5+) using 
 For optimized performance, install `torchao` (requires torch 2.10+):
 
 ```bash
-pip install pocket-tts[quantize]
+pip install 'pocket-tts[quantize]'
 ```
 
 The quantization module automatically selects the best available backend:


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `docs/quantization.md`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`