### PR TITLE
docs: correct GPU speedup claim + add CUDA usage notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,16 @@ This is a pure Python package with Rust extensions in `training/rust_exts/audio_
 
 - **Thread Safety**: The code is NOT thread-safe. Server mode does not support concurrent requests.
 - **Batching**: Batch size is always 1. No batching support currently.
-- **Device**: Defaults to CPU. GPU does not provide speedup for this small model.
+- **Device**: Defaults to CPU. Whether GPU helps is hardware-dependent: on hardware with strong
+  single-thread CPU performance (e.g. Apple Silicon) we did not observe a speedup, but on a cloud
+  x86 VM with a Tesla T4, `.to("cuda")` measured ~2.6x speedup over CPU (RTF ~2.3-2.5x CPU vs.
+  ~6.28x GPU). There is no `device` argument on `TTSModel.load_model()` (the `generate` CLI has an
+  undocumented `--device`; `serve` and Docker have none and are CPU-only). `generate_audio()`
+  returns a tensor on the model's device, so code moved to GPU must call `.detach().cpu().numpy()`
+  instead of `.numpy()`. `quantize=True` is CPU-only and raises `NotImplementedError` on CUDA; the
+  optional `torchao` backend currently requires `torch>=2.11`, newer than any released stable
+  `torch`, so installing it breaks `quantize=True` even on CPU. See README's "Running on GPU"
+  section for details.
 - **Torch Threads**: `torch.set_num_threads(1)` in `tts_model.py` for optimal CPU performance
 - **dtype**: Models use float32 by default (configurable in YAML)
 - **Beartype**: Runtime type checking is enabled via beartype claw in `__init__.py`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,13 +108,14 @@ This is a pure Python package with Rust extensions in `training/rust_exts/audio_
 - **Device**: Defaults to CPU. Whether GPU helps is hardware-dependent: on hardware with strong
   single-thread CPU performance (e.g. Apple Silicon) we did not observe a speedup, but on a cloud
   x86 VM with a Tesla T4, `.to("cuda")` measured ~2.6x speedup over CPU (RTF ~2.3-2.5x CPU vs.
-  ~6.28x GPU). There is no `device` argument on `TTSModel.load_model()` (the `generate` CLI has an
-  undocumented `--device`; `serve` and Docker have none and are CPU-only). `generate_audio()`
-  returns a tensor on the model's device, so code moved to GPU must call `.detach().cpu().numpy()`
-  instead of `.numpy()`. `quantize=True` is CPU-only and raises `NotImplementedError` on CUDA; the
-  optional `torchao` backend currently requires `torch>=2.11`, newer than any released stable
-  `torch`, so installing it breaks `quantize=True` even on CPU. See README's "Running on GPU"
-  section for details.
+  ~6.28x GPU). There is no `device` argument on `TTSModel.load_model()` (the `generate` CLI has a
+  documented `--device`, though its own doc page's "no speedup" note predates this finding; `serve`
+  and Docker have none and are CPU-only). `generate_audio()` returns a tensor on the model's device,
+  so code moved to GPU must call `.detach().cpu().numpy()` instead of `.numpy()`. `quantize=True` is
+  CPU-only and raises `NotImplementedError` on CUDA; the optional `torchao` backend declares
+  `torch>=2.11`, which a fresh install satisfies, but installing it on top of an older pinned
+  `torch` (e.g. for GPU driver compatibility) can break `quantize=True` even on CPU. See README's
+  "Running on GPU" section for details.
 - **Torch Threads**: `torch.set_num_threads(1)` in `tts_model.py` for optimal CPU performance
 - **dtype**: Models use float32 by default (configurable in YAML)
 - **Beartype**: Runtime type checking is enabled via beartype claw in `__init__.py`

--- a/README.md
+++ b/README.md
@@ -157,14 +157,53 @@ audio = model.generate_audio(model_state_copy, "Hello world!")
 
 You can check out the [Python API documentation](https://kyutai-labs.github.io/pocket-tts/API%20Reference/python-api/) for more details and examples.
 
+## Running on GPU
+
+Pocket TTS is designed to run on CPU, and on hardware with strong single-thread CPU performance
+(e.g. Apple Silicon) we did not observe a GPU speedup, notably because we use a batch size of 1
+and a very small model. However, this turns out to be hardware-dependent: measured on a cloud x86
+VM (4 vCPUs) with a Tesla T4, moving the model to GPU gave a consistent ~2.6x speedup over CPU
+(RTF ~2.3-2.5x on CPU vs. ~6.28x on GPU, for both short and long input text). If your CPU is
+thread-limited or otherwise weaker than a modern laptop chip, it's worth trying the GPU.
+
+This is not officially supported (there is no `device` argument on `TTSModel.load_model()`), but
+since `TTSModel` is a regular `nn.Module` you can move it yourself:
+
+```python
+tts_model = TTSModel.load_model()
+tts_model.to("cuda")
+...
+audio = tts_model.generate_audio(voice_state, "Hello world, this is a test.")
+# generate_audio() returns a tensor on the same device as the model, so on GPU you need
+# to move it back to CPU before calling .numpy():
+scipy.io.wavfile.write("output.wav", tts_model.sample_rate, audio.detach().cpu().numpy())
+```
+
+A few things to be aware of if you want to use the GPU:
+- The `generate` CLI command has an undocumented `--device` option (defaults to `cpu`); the
+  `serve` command and the Docker image do not expose any device option and will always run on CPU.
+- `pip install pocket-tts` / `uv add pocket-tts` install whatever `torch` build is current on
+  PyPI, which may require a newer CUDA version than your driver supports. In that case
+  `torch.cuda.is_available()` silently returns `False` (you'll only see a `UserWarning` about an
+  outdated driver, not an error). If this happens, install a `torch` build matching your driver's
+  CUDA version explicitly, e.g. `pip install torch --index-url https://download.pytorch.org/whl/cu121`.
+- `quantize=True` (int8 dynamic quantization) only works on CPU; calling it on a model moved to
+  CUDA raises `NotImplementedError: Could not run 'quantized::linear_dynamic' ... 'CUDA' backend`.
+  Additionally, as of this writing the optional `torchao` backend (`pip install pocket-tts[quantize]`)
+  requires `torch>=2.11`, which is newer than every currently released stable `torch`; installing it
+  will break `quantize=True` even on CPU. Don't install this extra until the repo documents a
+  compatible `torch` version.
+
 ## Unsupported features
 
 At the moment, we do not support (but would love pull requests adding):
 
 - [Adding silence in the text input to generate pauses.](https://github.com/kyutai-labs/pocket-tts/issues/6)
 
-We tried running this TTS model on the GPU but did not observe a speedup compared to CPU execution,
-notably because we use a batch size of 1 and a very small model.
+We tried running this TTS model on the GPU but did not observe a speedup compared to CPU execution
+on hardware with very strong single-thread CPU performance, notably because we use a batch size of
+1 and a very small model. See the ["Running on GPU"](#running-on-gpu) section above for measurements
+on other hardware and caveats if you want to try it yourself.
 
 ## Development and local setup
 

--- a/README.md
+++ b/README.md
@@ -180,8 +180,11 @@ scipy.io.wavfile.write("output.wav", tts_model.sample_rate, audio.detach().cpu()
 ```
 
 A few things to be aware of if you want to use the GPU:
-- The `generate` CLI command has an undocumented `--device` option (defaults to `cpu`); the
-  `serve` command and the Docker image do not expose any device option and will always run on CPU.
+- The `generate` CLI command has a `--device` option (defaults to `cpu`, documented in the
+  [CLI reference](docs/CLI%20Commands/generate.md) — note that page's own description ("you may not
+  get a speedup by using a gpu since it's a small model") is what this section is correcting, based
+  on the T4 measurements above); the `serve` command and the Docker image do not expose any device
+  option and will always run on CPU.
 - `pip install pocket-tts` / `uv add pocket-tts` install whatever `torch` build is current on
   PyPI, which may require a newer CUDA version than your driver supports. In that case
   `torch.cuda.is_available()` silently returns `False` (you'll only see a `UserWarning` about an
@@ -189,10 +192,12 @@ A few things to be aware of if you want to use the GPU:
   CUDA version explicitly, e.g. `pip install torch --index-url https://download.pytorch.org/whl/cu121`.
 - `quantize=True` (int8 dynamic quantization) only works on CPU; calling it on a model moved to
   CUDA raises `NotImplementedError: Could not run 'quantized::linear_dynamic' ... 'CUDA' backend`.
-  Additionally, as of this writing the optional `torchao` backend (`pip install pocket-tts[quantize]`)
-  requires `torch>=2.11`, which is newer than every currently released stable `torch`; installing it
-  will break `quantize=True` even on CPU. Don't install this extra until the repo documents a
-  compatible `torch` version.
+  Separately, the optional `torchao` backend (`pip install pocket-tts[quantize]`) declares
+  `torch>=2.11` — fine with a fresh install (torch 2.11+ is on PyPI as of this writing), but if
+  you've pinned an older `torch` (e.g. to match an older GPU driver's CUDA build, per the point
+  above), adding this extra can pull in a `torchao` that's incompatible with your pinned `torch`
+  and break `quantize=True` even on CPU. Match `torchao`'s `torch` requirement to whatever `torch`
+  you actually have installed.
 
 ## Unsupported features
 

--- a/docs/CLI Commands/generate.md
+++ b/docs/CLI Commands/generate.md
@@ -32,7 +32,7 @@ This will generate a WAV file `./tts_output.wav` with the default text and voice
 
 ### Performance Options
 
-- `--device DEVICE`: Device to use (default: "cpu", you may not get a speedup by using a gpu since it's a small model)
+- `--device DEVICE`: Device to use (default: "cpu"). Whether GPU helps is hardware-dependent — see the main [README's "Running on GPU" section](../../README.md#running-on-gpu) for measured numbers (no speedup observed on some CPUs with strong single-thread performance like Apple Silicon, but a measured ~2.6x speedup on a cloud x86 VM with a Tesla T4).
 - `--quantize`: Use int8 quantization for the model (default: False). This can reduce memory usage and increase speed, with minimal impact on audio quality.
 - `--quiet`, `-q`: Disable logging output
 


### PR DESCRIPTION
## Motivation

The README and AGENTS.md state that GPU gives no speedup for this model ("We tried running this TTS model on the GPU but did not observe a speedup compared to CPU execution, notably because we use a batch size of 1 and a very small model.").

That holds on hardware with very strong single-thread CPU performance (e.g. Apple Silicon, matching the README's own ~6x-real-time M4 headline). But measured on a cloud x86 VM (4 vCPUs) with a Tesla T4, moving the model to GPU gave a consistent **~2.6x speedup over CPU**:

| Metric | CPU (RTF) | GPU (RTF, `.to("cuda")`) | Speedup |
|---|---|---|---|
| Short text (~2.1-2.3s audio) | 2.306 | 6.286 | ~2.7x |
| Long text (~18s audio) | 2.499 | 6.279 | ~2.5x |

(RTF = real-time factor, higher is faster; min of 4 runs after 1 warmup run, <5% variance, GPU peak VRAM 560.5MB.) So this isn't wrong so much as hardware-dependent, and it's worth documenting for users on weaker/thread-limited CPUs where the GPU is still a meaningful win.

While reproducing this I also hit a few undocumented GPU rough edges worth flagging for anyone who tries `.to("cuda")` themselves:
- `generate_audio()` returns a tensor on the model's device, so the README's own quickstart crashes with `TypeError: can't convert cuda:0 device type tensor to numpy` if you naively add `.to("cuda")` — needs `.detach().cpu().numpy()` instead of `.numpy()`.
- `pip install pocket-tts` / `uv add pocket-tts` (the README's documented install path) can silently fall back to CPU on driver/CUDA version mismatches — you only get a `UserWarning`, not an error, so `torch.cuda.is_available()` quietly returns `False`.
- `serve` and the Docker image have no device option at all and are always CPU-only (only the `generate` CLI has a hidden, undocumented `--device`).
- `quantize=True` (int8) is CPU-only and raises `NotImplementedError` if the model has been moved to CUDA.
- The optional `torchao` quantize extra (`pip install pocket-tts[quantize]`) currently requires `torch>=2.11`, newer than any released stable torch, so installing it breaks `quantize=True` even on CPU.

## Changes

Doc-only, no code changes:
- Added a new "Running on GPU" section to README.md with the measurements above, the `.to("cuda")` + `.detach().cpu().numpy()` snippet, and the caveats listed above.
- Softened/contextualized the "Unsupported features" GPU paragraph to note this is hardware-dependent and point to the new section.
- Updated AGENTS.md's "Device" bullet with the same hardware-dependent nuance and caveats, for coding agents working on this repo.

## Testing

- Docs-only change; ran `uv run pytest -n 3 -v` locally to confirm `tests/test_documentation_examples.py` and the rest of the suite still pass unmodified.
- GPU numbers above were reproduced end-to-end via the repo's public API only (`TTSModel.load_model()` / `.to()` / `.generate_audio()`), no internals touched, on a real Tesla T4 (16GB), driver 550.163.01, torch 2.5.1+cu121.