### PR TITLE
Fix decimal splitting in sentence chunker

### DIFF
--- a/pocket_tts/models/tts_model.py
+++ b/pocket_tts/models/tts_model.py
@@ -942,20 +942,48 @@ def prepare_text_prompt(
     return text, frames_after_eos_guess
 
 
-def _find_boundary_indices(list_of_tokens: list[int], boundary_tokens: list[int]) -> list[int]:
+def _is_decimal_period_boundary(
+    list_of_tokens: list[int], segment_start_idx: int, tokenizer
+) -> bool:
+    """Return True when segment_start_idx begins right after a decimal period."""
+    prefix = tokenizer.sp.decode(list_of_tokens[:segment_start_idx])
+    suffix = tokenizer.sp.decode(list_of_tokens[segment_start_idx:])
+    return (
+        len(prefix) >= 2
+        and prefix[-1] == "."
+        and prefix[-2].isdigit()
+        and bool(suffix)
+        and suffix[0].isdigit()
+    )
+
+
+def _find_boundary_indices(
+    list_of_tokens: list[int],
+    boundary_tokens: list[int],
+    tokenizer=None,
+    skip_decimal_periods: bool = False,
+) -> list[int]:
     """Find token indices where text should be split based on boundary tokens.
 
     Returns a list of boundary positions used to slice segments. Each consecutive
     pair (indices[i], indices[i+1]) defines one segment. The first element is
     always 0 and the last is always len(list_of_tokens).
     """
+    boundary_set = set(boundary_tokens)
     indices = [0]
     previous_was_boundary = False
     for idx, token in enumerate(list_of_tokens):
-        if token in boundary_tokens:
+        if token in boundary_set:
             previous_was_boundary = True
         else:
             if previous_was_boundary:
+                if (
+                    skip_decimal_periods
+                    and tokenizer is not None
+                    and _is_decimal_period_boundary(list_of_tokens, idx, tokenizer)
+                ):
+                    previous_was_boundary = False
+                    continue
                 indices.append(idx)
             previous_was_boundary = False
     indices.append(len(list_of_tokens))
@@ -990,7 +1018,9 @@ def split_into_best_sentences(
     list_of_tokens = tokens.tokens[0].tolist()
 
     _, *end_of_sentence_tokens = tokenizer(".!...?").tokens[0].tolist()
-    sentence_boundaries = _find_boundary_indices(list_of_tokens, end_of_sentence_tokens)
+    sentence_boundaries = _find_boundary_indices(
+        list_of_tokens, end_of_sentence_tokens, tokenizer, skip_decimal_periods=True
+    )
     nb_tokens_and_sentences = _segments_from_boundaries(
         list_of_tokens, sentence_boundaries, tokenizer
     )

--- a/tests/test_split_sentences.py
+++ b/tests/test_split_sentences.py
@@ -128,6 +128,64 @@ def test_empty_string_raises(tokenizer):
         )
 
 
+def test_decimals_are_not_split_on_period(tokenizer):
+    """Decimal periods must not be treated as sentence boundaries (issue #162)."""
+    text = (
+        "The average human body temperature is 98.6°F, "
+        "which is a common decimal used in medicine."
+    )
+    chunks = split_into_best_sentences(
+        tokenizer, text, 50, pad_with_spaces_for_short_inputs=False, remove_semicolons=False
+    )
+    assert len(chunks) == 1
+    assert "98.6" in chunks[0]
+    assert "98. 6" not in chunks[0]
+
+
+def test_multiple_decimals_in_one_sentence(tokenizer):
+    """Several decimals in one sentence should stay intact."""
+    text = "Pi is 3.14 and e is 2.718."
+    chunks = split_into_best_sentences(
+        tokenizer, text, 50, pad_with_spaces_for_short_inputs=False, remove_semicolons=False
+    )
+    assert len(chunks) == 1
+    assert "3.14" in chunks[0]
+    assert "2.718" in chunks[0]
+    assert "3. 14" not in chunks[0]
+    assert "2. 718" not in chunks[0]
+
+
+def test_decimal_followed_by_sentence_boundary(tokenizer):
+    """Decimals should be preserved while real sentence boundaries still split."""
+    text = (
+        "The average human body temperature is 98.6°F, "
+        "which is a common decimal used in medicine. "
+        "Pi is 3.14 and e is 2.718."
+    )
+    chunks = split_into_best_sentences(
+        tokenizer, text, 20, pad_with_spaces_for_short_inputs=False, remove_semicolons=False
+    )
+    assert len(chunks) >= 2
+    rejoined = " ".join(chunks)
+    assert "98.6" in rejoined
+    assert "3.14" in rejoined
+    assert "2.718" in rejoined
+    assert "98. 6" not in rejoined
+    assert "3. 14" not in rejoined
+
+
+def test_sentence_period_after_decimal_still_splits(tokenizer):
+    """A period ending a sentence after a decimal is still a boundary."""
+    text = "Version 2.0 is out. Pi is 3.14."
+    chunks = split_into_best_sentences(
+        tokenizer, text, 50, pad_with_spaces_for_short_inputs=False, remove_semicolons=False
+    )
+    assert len(chunks) == 1
+    assert "2.0" in chunks[0]
+    assert "3.14" in chunks[0]
+    assert "2. 0" not in chunks[0]
+
+
 def test_oversized_clause_without_commas_still_returns(tokenizer):
     """A long clause with no split points should still be returned (not dropped)."""
     # 20 words with no punctuation at all - no way to split

--- a/tests/test_split_sentences.py
+++ b/tests/test_split_sentences.py
@@ -131,8 +131,7 @@ def test_empty_string_raises(tokenizer):
 def test_decimals_are_not_split_on_period(tokenizer):
     """Decimal periods must not be treated as sentence boundaries (issue #162)."""
     text = (
-        "The average human body temperature is 98.6°F, "
-        "which is a common decimal used in medicine."
+        "The average human body temperature is 98.6°F, which is a common decimal used in medicine."
     )
     chunks = split_into_best_sentences(
         tokenizer, text, 50, pad_with_spaces_for_short_inputs=False, remove_semicolons=False


### PR DESCRIPTION
## Summary
- Skip sentence boundaries when a period separates two digits (e.g. `98.6`, `3.14`)
- Add regression tests for issue #162

## Test plan
- [x] `uv run pytest tests/test_split_sentences.py -v`