### PR TITLE
Document CPU-only installation (pip pulls ~3 GB of CUDA wheels by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Navigate to the [Kyutai website](https://kyutai.org/pocket-tts) to try it out di
 You can use pocket-tts directly from the command line. We recommend using
 `uv` as it installs any dependencies on the fly in an isolated environment (uv installation instructions [here](https://docs.astral.sh/uv/getting-started/installation/#standalone-installer)).
 You can also use `pip install pocket-tts` to install it manually.
+On Linux, see [CPU-only installation](#cpu-only-installation) to avoid pulling in the CUDA build of PyTorch.
 
 This will generate a wav file `./tts_output.wav` saying the default text with the default voice, and display some speed statistics.
 ```bash
@@ -115,6 +116,28 @@ pip install pocket-tts
 # or
 uv add pocket-tts
 ```
+
+### CPU-only installation
+
+On Linux, PyPI serves the CUDA build of PyTorch by default, so `pip install pocket-tts` also
+downloads the `nvidia-*` CUDA runtime wheels (~3 GB), even though pocket-tts runs on CPU.
+To get the CPU build instead (~200 MB, no NVIDIA packages), install from the PyTorch CPU index:
+```bash
+pip install pocket-tts --extra-index-url https://download.pytorch.org/whl/cpu
+```
+
+With `uv`, declare the index explicitly in your project:
+```toml
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
+
+[tool.uv.sources]
+torch = [{ index = "pytorch-cpu" }]
+```
+
+This is not needed on macOS or Windows, where the default PyTorch wheels are already CPU-only.
 
 You can use this package as a simple Python library to generate audio from text.
 ```python

--- a/README.md
+++ b/README.md
@@ -120,10 +120,16 @@ uv add pocket-tts
 ### CPU-only installation
 
 On Linux, PyPI serves the CUDA build of PyTorch by default, so `pip install pocket-tts` also
-downloads the `nvidia-*` CUDA runtime wheels (~3 GB), even though pocket-tts runs on CPU.
-To get the CPU build instead (~200 MB, no NVIDIA packages), install from the PyTorch CPU index:
+downloads the `nvidia-*` CUDA runtime wheels, even though pocket-tts runs on CPU. This adds
+several gigabytes to the install (with torch 2.13, roughly 3 GB instead of 200 MB). Installing
+from the PyTorch CPU index pulls the CPU build and no NVIDIA packages:
 ```bash
 pip install pocket-tts --extra-index-url https://download.pytorch.org/whl/cpu
+```
+
+To run the CLI without installing, pass the same index to `uvx`:
+```bash
+uvx --index https://download.pytorch.org/whl/cpu pocket-tts generate
 ```
 
 With `uv`, declare the index explicitly in your project:


### PR DESCRIPTION
The README says pocket-tts is "designed to run efficiently on CPUs" and that it "does not require the gpu version of PyTorch" — but on Linux, `pip install pocket-tts` installs exactly that: the CUDA build of torch plus the whole `nvidia-*` runtime stack.

### Reproduction

```
$ uv pip install --dry-run pocket-tts
Would install 66 packages
 + torch==2.13.0
 + nvidia-cublas==13.1.1.3
 + nvidia-cuda-cupti==13.0.85
 + nvidia-cudnn-cu13==9.20.0.48
 + nvidia-nccl-cu13==2.29.7
 ... (15 nvidia-* packages in total)
```

Summed wheel sizes: **~3.07 GB**, of which torch + the NVIDIA CUDA wheels are ~2.81 GB.

With the PyTorch CPU index, the same install is 47 packages, zero `nvidia-*` wheels, and a 192 MB torch wheel:

```
$ uv pip install --dry-run pocket-tts --extra-index-url https://download.pytorch.org/whl/cpu
Would install 47 packages
 + torch==2.13.0+cpu
```

The repo already routes torch to the CPU index for local development via `[tool.uv.sources]` in `pyproject.toml`, so contributors never see this — only end users installing from PyPI do. This bites people on disk-constrained machines, in slim containers, and in CI.

### This PR

Documentation only, no packaging changes: adds a **CPU-only installation** section to the README covering the `--extra-index-url` flag for pip and the equivalent `[tool.uv.index]` / `[tool.uv.sources]` block for uv, plus a pointer from the CLI install section. Notes that macOS and Windows are unaffected, since their default PyPI wheels are already CPU-only.

### Alternative worth considering

A packaging-level fix (e.g. `cpu` / `gpu` extras) would make the default install small without users needing to know about index URLs. I left it out because moving `torch` out of `dependencies` would break plain `pip install pocket-tts` and `uvx pocket-tts generate` for everyone unless a default is kept, and that trade-off feels like a maintainer call. Happy to follow up with that approach if you prefer it.