### PR TITLE
OpenAI compatible API endpoint (/v1/audio/speech)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ pocket-tts serve
 ```
 Navigate to `http://localhost:8000` to try the web interface, it's faster than the command line as the model is kept in memory between requests.
 
+The server also exposes an OpenAI API-compatible endpoint (`/v1/audio/speech`) and supports loading custom voices from a folder:
+```bash
+uvx pocket-tts serve --voices-folder ./my_voices
+```
+All `.wav`, `.mp3`, and `.safetensors` files in the folder are registered as voices (filename without extension = voice name).
+
 You can check out the [serve documentation](https://kyutai-labs.github.io/pocket-tts/CLI%20Commands/serve/) for more details and examples.
 
 ### The `export-voice` command

--- a/docs/API Reference/openai-api.md
+++ b/docs/API Reference/openai-api.md
@@ -1,0 +1,86 @@
+# OpenAI-Compatible API
+
+The `serve` command exposes OpenAI-compatible TTS endpoints under the `/v1` prefix. This allows you to use Pocket TTS with any tool or library that supports the OpenAI speech API.
+
+## Starting the Server
+
+```bash
+# Basic usage
+uvx pocket-tts serve
+
+# With custom voices from a folder
+uvx pocket-tts serve --voices-folder ./my_voices
+```
+
+## Endpoints
+
+### Generate Speech
+
+**`POST /v1/audio/speech`**
+
+Generate speech from text and return audio as a WAV file.
+
+**Request Body (JSON):**
+
+| Field             | Type   | Required | Default        | Description                                              |
+| ----------------- | ------ | -------- | -------------- | -------------------------------------------------------- |
+| `model`           | string | No       | `"pocket-tts"` | Model identifier (ignored)                               |
+| `input`           | string | **Yes**  | —              | Text to synthesize                                       |
+| `voice`           | string | No       | `"alba"`       | Voice name (built-in or custom)                          |
+| `response_format` | string | No       | `"wav"`        | Output format (ignored, only `wav` is actually produced) |
+| `speed`           | float  | No       | `1.0`          | Playback speed multiplier (ignored)                      |
+
+**Response:**
+
+- `200 OK` — WAV audio bytes (`Content-Type: audio/wav`)
+- `400 Bad Request` — Invalid input (empty text, unknown voice)
+
+**Example:**
+
+```bash
+curl -X POST http://localhost:8000/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input": "Hello world, this is a test.",
+    "voice": "alba"
+  }' \
+  --output speech.wav
+```
+
+**Python (openai package):**
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+response = client.audio.speech.create(
+    model="pocket-tts", voice="alba", input="Hello world, this is a test.", response_format="wav"
+)
+response.write_to_file("speech.wav")
+```
+
+## Custom Voices
+
+Use `--voices-folder` to register custom voices at startup:
+
+```bash
+# Place voice files in a directory
+mkdir -p my_voices
+cp my_speaker.wav my_voices/
+cp cloned_voice.safetensors my_voices/
+
+# Start the server
+uvx pocket-tts serve --voices-folder ./my_voices
+```
+
+All `.wav`, `.mp3`, and `.safetensors` files in the folder are registered. The filename without extension becomes the voice name (e.g., `my_speaker.wav` → `"my_speaker"`).
+
+Custom voices take priority over built-in voices if names collide. Use `.safetensors` files (created via [`export-voice`](export_voice.md)) for the fastest loading.
+
+## Differences from OpenAI
+
+- Only `wav` format is actually produced regardless of `response_format`
+- `model` and `speed` parameters are also accepted but ignored
+- No streaming support (returns complete WAV file)
+- Voice names differ from OpenAI's (`alba`, `anna`, etc. instead of `alloy`, `nova`, etc.)

--- a/docs/CLI Commands/serve.md
+++ b/docs/CLI Commands/serve.md
@@ -20,6 +20,8 @@ This starts a server on `http://localhost:8000` with the default voice model.
 - `--language`: Language for the TTS model, one of `'english_2026-01'`, `'english_2026-04'`, `'english'`, `'french_24l'`, `'german_24l'`, `'portuguese_24l'`, `'italian_24l'`, `'spanish_24l'` (default: `english`, which is the same model as `'english_2026-04'`). Incompatible with `--config`. The "24l" variants are bigger models, not distilled yet and here only as preview.
 - `--config`: Path to a custom config .yaml. Incompatible with `--language`.
 - `--quantize`: Use int8 quantization for the model (default: False). This can reduce memory usage and increase speed, with minimal impact on audio quality.
+- `--voices-folder PATH`: Path to a folder containing custom voice files (`.wav`, `.mp3`, `.safetensors`). File names without extension become voice names available on the `/v1/audio/speech` endpoint.
+
 ## Examples
 
 ### Basic Server
@@ -30,10 +32,15 @@ pocket-tts serve
 
 # Custom host and port
 pocket-tts serve --host "localhost" --port 8080
+
+# With custom voices folder
+pocket-tts serve --voices-folder ./my_voices
 ```
 
 ### Custom Language
+
 To select the default language model, pass `--language`:
+
 ```bash
 pocket-tts serve --language french_24l
 ```
@@ -50,6 +57,16 @@ Then, use the --config option to point to your newly created config.
 # Use a different config
 pocket-tts serve --config "C://pocket-tts/my_config.yaml"
 ```
+
+### Custom Voices Folder
+
+Place voice files in a folder and register them all at once:
+
+```bash
+pocket-tts serve --voices-folder ./my_voices
+```
+
+All `.wav`, `.mp3`, and `.safetensors` files in the folder are loaded as custom voices. The filename without extension becomes the voice name (e.g., `my_speaker.wav` → voice name `my_speaker`). Custom voices are available on the `/v1/audio/speech` [OpenAI-compatible endpoint](openai-api.md).
 
 ## Web Interface
 

--- a/pocket_tts/main.py
+++ b/pocket_tts/main.py
@@ -14,6 +14,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, StreamingResponse
 from typing_extensions import Annotated
 
+from pocket_tts import openai_api
 from pocket_tts.data.audio import stream_audio_chunks
 from pocket_tts.default_parameters import (
     DEFAULT_EOS_THRESHOLD,
@@ -57,6 +58,7 @@ web_app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+web_app.include_router(openai_api.router)
 
 
 @web_app.get("/", response_class=HTMLResponse)
@@ -205,11 +207,33 @@ def serve(
     quantize: Annotated[
         bool, typer.Option(help="Apply int8 quantization to reduce memory usage")
     ] = False,
+    voices_folder: Annotated[
+        str | None,
+        typer.Option(
+            help="Path to a folder containing voice files (.wav, .mp3, .safetensors). "
+            "File names (without extension) become voice names for the /v1/audio/speech endpoint."
+        ),
+    ] = None,
 ):
     """Start the FastAPI server."""
 
     global tts_model
     tts_model = TTSModel.load_model(language=language, config=config, quantize=quantize)
+    openai_api.set_model(tts_model)
+
+    # Load custom voices from folder
+    if voices_folder is not None:
+        voices_dir = Path(voices_folder)
+        if not voices_dir.is_dir():
+            logger.error("Voices folder not found: %s", voices_folder)
+            raise typer.Exit(code=1)
+        custom_voices = {}
+        for ext in (".wav", ".mp3", ".safetensors"):
+            for filepath in voices_dir.glob(f"*{ext}"):
+                name = filepath.stem
+                custom_voices[name] = str(filepath)
+                logger.info("Registered custom voice '%s' from %s", name, filepath)
+        openai_api.set_custom_voices(custom_voices)
 
     uvicorn.run("pocket_tts.main:web_app", host=host, port=port, reload=reload)
 

--- a/pocket_tts/openai_api.py
+++ b/pocket_tts/openai_api.py
@@ -1,0 +1,72 @@
+"""
+OpenAI API-compatible TTS endpoint mounted at `/v1/audio/speech`.
+"""
+
+import io
+
+import numpy as np
+import scipy.io.wavfile
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import Response
+from pydantic import BaseModel, Field
+
+from pocket_tts.utils.utils import _ORIGINS_OF_PREDEFINED_VOICES
+
+router = APIRouter(prefix="/v1")
+
+# Globals set by main.py at startup
+_tts_model = None
+_custom_voices: dict[str, str] = {}
+
+
+def set_model(model):
+    global _tts_model
+    _tts_model = model
+
+
+def set_custom_voices(voices: dict[str, str]):
+    """Register custom voices mapping names to file paths."""
+    global _custom_voices
+    _custom_voices = voices
+
+
+class SpeechRequest(BaseModel):
+    model: str = Field(default="pocket-tts", description="Model identifier (ignored)")
+    input: str = Field(..., description="Text to synthesize")
+    voice: str = Field(default="alba", description="Voice name")
+    response_format: str = Field(default="wav", description="Output format (ignored)")
+    speed: float = Field(default=1.0, description="Playback speed (ignored)")
+
+
+@router.post("/audio/speech")
+def create_speech(req: SpeechRequest):
+    """OpenAI-compatible speech generation endpoint."""
+    if not req.input.strip():
+        raise HTTPException(status_code=400, detail="`input` must be a non-empty string.")
+
+    voice_path = _resolve_voice(req.voice)
+    model_state = _tts_model._cached_get_state_for_audio_prompt(voice_path)
+    audio_tensor = _tts_model.generate_audio(model_state, req.input)
+    audio_int16 = (np.clip(audio_tensor.detach().cpu().numpy(), -1.0, 1.0) * 32767).astype(np.int16)
+    wav_io = io.BytesIO()
+    scipy.io.wavfile.write(wav_io, _tts_model.sample_rate, audio_int16)
+    wav_io.seek(0)
+    return Response(
+        content=wav_io.read(),
+        media_type="audio/wav",
+        headers={"Content-Disposition": 'attachment; filename="speech.wav"'},
+    )
+
+
+def _resolve_voice(voice_name: str) -> str:
+    """Resolve a voice name to a path/URL the model can consume.
+    Checks custom voices first, then predefined voices.
+    """
+    if voice_name in _custom_voices:
+        return _custom_voices[voice_name]
+    if voice_name in _ORIGINS_OF_PREDEFINED_VOICES:
+        return voice_name  # predefined name is resolved inside get_state_for_audio_prompt
+    all_names = list(_custom_voices.keys()) + list(_ORIGINS_OF_PREDEFINED_VOICES.keys())
+    raise HTTPException(
+        status_code=400, detail=f"Unknown voice '{voice_name}'. Available voices: {all_names}"
+    )


### PR DESCRIPTION
Hi, I forked the repo to implement an openai api compatible endpoint so I can try `pocket-tts` with `open-webui`.  
Since many tools work well with this interface, it could be considered to add this to pocket-tts for wider adoption. Feel free to merge my fork if it's useful.

Add openai compatible api endpoints:
- `POST` `/v1/audio/speech`
- served along the existing `/tts` endpoint
- minimal implementation, only `wav` response_format, no streaming
- 'voices-folder' argument: all sound files and custom voice models are read from here and registered as available voices
- including documentation

---

The solution works well with open-webui:
<img width="386" height="161" alt="image" src="https://github.com/user-attachments/assets/43188199-0420-4cdb-9e59-98dca321be47" />
If anyone wants to try it, this is the config in the admin settings:
<img width="423" height="200" alt="image" src="https://github.com/user-attachments/assets/0e468da9-ecb5-4a24-9d99-680c3b5d2095" />
(`TTS Voice` field can be any predefined or custom voice name, `TTS Model` field is ignored)

---

Thanks for reviewing, I'm open to resolve change requests.