### PR TITLE
Default the English model's temperature to 0.3

### DIFF
--- a/docs/API Reference/python-api.md
+++ b/docs/API Reference/python-api.md
@@ -37,14 +37,14 @@ The main class for text-to-speech generation.
 
 #### Class Methods
 
-##### `load_model(language=None, config=None, temp=0.7, lsd_decode_steps=1, noise_clamp=None, eos_threshold=-4.0, quantize=False)`
+##### `load_model(language=None, config=None, temp=None, lsd_decode_steps=1, noise_clamp=None, eos_threshold=-4.0, quantize=False)`
 
 Load and return a TTSModel instance with pre-trained weights.
 
 **Parameters:**
 - `language` (str | None): Name of built-in language config to load. Supported values: `"english_2026-01"`, `"english_2026-04"`, `"english"`, `"french_24l"`, `"german_24l"`, `"portuguese_24l"`, `"italian_24l"`, `"spanish_24l"`. If both `language` and `config` are omitted, defaults to `"english"`, which is the same model as `"english_2026-04"`. The "24l" variants are larger models that are not distilled yet and are here only as a preview.
 - `config` (str | None): Path to model config YAML file. Incompatible with `language`.
-- `temp` (float): Sampling temperature for generation (default: 0.7)
+- `temp` (float | None): Sampling temperature for generation. `None` uses the language's tuned default: 0.3 for English, 0.7 for other languages.
 - `lsd_decode_steps` (int): Number of generation steps (default: 1)
 - `noise_clamp` (float | None): Maximum value for noise sampling (default: None)
 - `eos_threshold` (float): Threshold for end-of-sequence detection (default: -4.0)

--- a/docs/API Reference/python-api.md
+++ b/docs/API Reference/python-api.md
@@ -44,7 +44,7 @@ Load and return a TTSModel instance with pre-trained weights.
 **Parameters:**
 - `language` (str | None): Name of built-in language config to load. Supported values: `"english_2026-01"`, `"english_2026-04"`, `"english"`, `"french_24l"`, `"german_24l"`, `"portuguese_24l"`, `"italian_24l"`, `"spanish_24l"`. If both `language` and `config` are omitted, defaults to `"english"`, which is the same model as `"english_2026-04"`. The "24l" variants are larger models that are not distilled yet and are here only as a preview.
 - `config` (str | None): Path to model config YAML file. Incompatible with `language`.
-- `temp` (float | None): Sampling temperature for generation. `None` uses the language's tuned default: 0.3 for English, 0.7 for other languages.
+- `temp` (float | None): Sampling temperature for generation. `None` uses the model's recommended default from its config file (`default_temperature`; 0.3 for the English model, 0.7 otherwise).
 - `lsd_decode_steps` (int): Number of generation steps (default: 1)
 - `noise_clamp` (float | None): Maximum value for noise sampling (default: None)
 - `eos_threshold` (float): Threshold for end-of-sequence detection (default: -4.0)

--- a/docs/CLI Commands/generate.md
+++ b/docs/CLI Commands/generate.md
@@ -25,7 +25,7 @@ This will generate a WAV file `./tts_output.wav` with the default text and voice
 
 - `--config CONFIG_PATH`: Path to custom config.yaml (for loading local model files). Incompatible with `--language`.
 - `--lsd-decode-steps LSD_DECODE_STEPS`: Number of generation steps (default: 1)
-- `--temperature TEMPERATURE`: Temperature for generation (default: the model's tuned value — 0.3 for English, 0.7 for other languages)
+- `--temperature TEMPERATURE`: Temperature for generation (default: the model's recommended value from its config — 0.3 for the English model, 0.7 otherwise)
 - `--noise-clamp NOISE_CLAMP`: Noise clamp value (default: None)
 - `--eos-threshold EOS_THRESHOLD`: EOS threshold (default: -4.0)
 - `--frames-after-eos FRAMES_AFTER_EOS`: Number of frames to generate after EOS (default: None, auto-calculated based on the text length). Each frame is 80ms.

--- a/docs/CLI Commands/generate.md
+++ b/docs/CLI Commands/generate.md
@@ -25,7 +25,7 @@ This will generate a WAV file `./tts_output.wav` with the default text and voice
 
 - `--config CONFIG_PATH`: Path to custom config.yaml (for loading local model files). Incompatible with `--language`.
 - `--lsd-decode-steps LSD_DECODE_STEPS`: Number of generation steps (default: 1)
-- `--temperature TEMPERATURE`: Temperature for generation (default: 0.7)
+- `--temperature TEMPERATURE`: Temperature for generation (default: the model's tuned value — 0.3 for English, 0.7 for other languages)
 - `--noise-clamp NOISE_CLAMP`: Noise clamp value (default: None)
 - `--eos-threshold EOS_THRESHOLD`: EOS threshold (default: -4.0)
 - `--frames-after-eos FRAMES_AFTER_EOS`: Number of frames to generate after EOS (default: None, auto-calculated based on the text length). Each frame is 80ms.

--- a/pocket_tts/config/english.yaml
+++ b/pocket_tts/config/english.yaml
@@ -2,6 +2,8 @@
 
 weights_path: hf://kyutai/pocket-tts/languages/english/model.safetensors@39592ff23c9ef80098bb74895d104c26275fe2c9
 weights_path_without_voice_cloning: hf://kyutai/pocket-tts-without-voice-cloning/languages/english/model.safetensors@d29db7978e464fb90cb3359ee0c69a273b9142cc
+# Human evals preferred this model at 0.3 (equal WER/similarity/speech rate).
+default_temperature: 0.3
 
 
 flow_lm:

--- a/pocket_tts/config/english_2026-04.yaml
+++ b/pocket_tts/config/english_2026-04.yaml
@@ -2,6 +2,8 @@
 
 weights_path: hf://kyutai/pocket-tts/languages/english_2026-04/model.safetensors@19f95fe2df36e79fbd9f10008595cc4c977a0fcc
 weights_path_without_voice_cloning: hf://kyutai/pocket-tts-without-voice-cloning/languages/english_2026-04/model.safetensors@d29db7978e464fb90cb3359ee0c69a273b9142cc
+# Human evals preferred this model at 0.3 (equal WER/similarity/speech rate).
+default_temperature: 0.3
 
 
 flow_lm:

--- a/pocket_tts/default_parameters.py
+++ b/pocket_tts/default_parameters.py
@@ -1,9 +1,5 @@
 DEFAULT_LANGUAGE = "english"
 DEFAULT_TEMPERATURE = 0.7
-# Human evals (pairwise, 400 judgments) preferred the English model at a lower
-# temperature: same intelligibility (WER), speaker similarity and speech rate,
-# noticeably better perceived quality.
-DEFAULT_TEMPERATURE_FOR_LANGUAGE = {"english": 0.3}
 DEFAULT_LSD_DECODE_STEPS = 1
 DEFAULT_NOISE_CLAMP = None
 DEFAULT_EOS_THRESHOLD = -4.0
@@ -59,13 +55,6 @@ def get_default_text_for_language(language: str | None) -> str:
         if language is not None and key in language:
             return text
     return DEFAULT_TEXT_FOR_LANGUAGE[DEFAULT_LANGUAGE]
-
-
-def get_default_temperature_for_language(language: str | None) -> float:
-    for key, temperature in DEFAULT_TEMPERATURE_FOR_LANGUAGE.items():
-        if language is not None and key in language:
-            return temperature
-    return DEFAULT_TEMPERATURE
 
 
 def get_default_voice_for_language(language: str | None) -> str:

--- a/pocket_tts/default_parameters.py
+++ b/pocket_tts/default_parameters.py
@@ -1,5 +1,9 @@
 DEFAULT_LANGUAGE = "english"
 DEFAULT_TEMPERATURE = 0.7
+# Human evals (pairwise, 400 judgments) preferred the English model at a lower
+# temperature: same intelligibility (WER), speaker similarity and speech rate,
+# noticeably better perceived quality.
+DEFAULT_TEMPERATURE_FOR_LANGUAGE = {"english": 0.3}
 DEFAULT_LSD_DECODE_STEPS = 1
 DEFAULT_NOISE_CLAMP = None
 DEFAULT_EOS_THRESHOLD = -4.0
@@ -55,6 +59,13 @@ def get_default_text_for_language(language: str | None) -> str:
         if language is not None and key in language:
             return text
     return DEFAULT_TEXT_FOR_LANGUAGE[DEFAULT_LANGUAGE]
+
+
+def get_default_temperature_for_language(language: str | None) -> float:
+    for key, temperature in DEFAULT_TEMPERATURE_FOR_LANGUAGE.items():
+        if language is not None and key in language:
+            return temperature
+    return DEFAULT_TEMPERATURE
 
 
 def get_default_voice_for_language(language: str | None) -> str:

--- a/pocket_tts/main.py
+++ b/pocket_tts/main.py
@@ -20,7 +20,6 @@ from pocket_tts.default_parameters import (
     DEFAULT_FRAMES_AFTER_EOS,
     DEFAULT_LSD_DECODE_STEPS,
     DEFAULT_NOISE_CLAMP,
-    DEFAULT_TEMPERATURE,
     MAX_TOKEN_PER_CHUNK,
     get_default_text_for_language,
     get_default_voice_for_language,
@@ -261,8 +260,12 @@ def generate(
         int, typer.Option(help="Number of generation steps")
     ] = DEFAULT_LSD_DECODE_STEPS,
     temperature: Annotated[
-        float, typer.Option(help="Temperature for generation")
-    ] = DEFAULT_TEMPERATURE,
+        float | None,
+        typer.Option(
+            help="Temperature for generation. Defaults to the model's tuned value "
+            "(0.3 for English, 0.7 for other languages)."
+        ),
+    ] = None,
     noise_clamp: Annotated[float, typer.Option(help="Noise clamp value")] = DEFAULT_NOISE_CLAMP,
     eos_threshold: Annotated[float, typer.Option(help="EOS threshold")] = DEFAULT_EOS_THRESHOLD,
     frames_after_eos: Annotated[

--- a/pocket_tts/main.py
+++ b/pocket_tts/main.py
@@ -262,8 +262,8 @@ def generate(
     temperature: Annotated[
         float | None,
         typer.Option(
-            help="Temperature for generation. Defaults to the model's tuned value "
-            "(0.3 for English, 0.7 for other languages)."
+            help="Temperature for generation. Defaults to the model's recommended "
+            "value from its config (0.3 for the English model, 0.7 otherwise)."
         ),
     ] = None,
     noise_clamp: Annotated[float, typer.Option(help="Noise clamp value")] = DEFAULT_NOISE_CLAMP,

--- a/pocket_tts/models/tts_model.py
+++ b/pocket_tts/models/tts_model.py
@@ -26,7 +26,6 @@ from pocket_tts.default_parameters import (
     DEFAULT_LSD_DECODE_STEPS,
     DEFAULT_NOISE_CLAMP,
     MAX_TOKEN_PER_CHUNK,
-    get_default_temperature_for_language,
 )
 from pocket_tts.models.flow_lm import FlowLMModel
 from pocket_tts.models.mimi import MimiModel
@@ -254,7 +253,8 @@ class TTSModel(nn.Module):
             config: A path to a custom YAML config file saved locally (e.g., `"C://pocket_tts/pocket_tts_config.yaml"`).
             temp: Sampling temperature for generation. Higher values produce more
                 diverse but potentially lower quality output. If None, defaults to
-                the language's tuned value (0.3 for English, 0.7 otherwise).
+                the model's recommended value from its config file
+                (``default_temperature``, e.g. 0.3 for the English model).
             lsd_decode_steps: Number of steps for Lagrangian Self Distillation
                 decoding. More steps can improve quality but increase computation.
             noise_clamp: Maximum value for noise sampling. If None, no clamping
@@ -293,8 +293,6 @@ class TTSModel(nn.Module):
             )
         if config is None and language is None:
             language = DEFAULT_LANGUAGE
-        if temp is None:
-            temp = get_default_temperature_for_language(language)
         if language is not None:
             if language == "french":
                 raise ValueError(
@@ -306,6 +304,8 @@ class TTSModel(nn.Module):
             raise ValueError("Config should be a path to a YAML file ending with .yaml")
         config_path = Path(config)
         config = load_config(config_path)
+        if temp is None:
+            temp = config.default_temperature
         logger.info(f"Loading model from config at {config_path}...")
 
         tts_model = TTSModel._from_pydantic_config_with_weights(

--- a/pocket_tts/models/tts_model.py
+++ b/pocket_tts/models/tts_model.py
@@ -25,8 +25,8 @@ from pocket_tts.default_parameters import (
     DEFAULT_LANGUAGE,
     DEFAULT_LSD_DECODE_STEPS,
     DEFAULT_NOISE_CLAMP,
-    DEFAULT_TEMPERATURE,
     MAX_TOKEN_PER_CHUNK,
+    get_default_temperature_for_language,
 )
 from pocket_tts.models.flow_lm import FlowLMModel
 from pocket_tts.models.mimi import MimiModel
@@ -234,7 +234,7 @@ class TTSModel(nn.Module):
         cls,
         language: str | None = None,
         config: str | Path | None = None,
-        temp: float | int = DEFAULT_TEMPERATURE,
+        temp: float | int | None = None,
         lsd_decode_steps: int = DEFAULT_LSD_DECODE_STEPS,
         noise_clamp: float | int | None = DEFAULT_NOISE_CLAMP,
         eos_threshold: float = DEFAULT_EOS_THRESHOLD,
@@ -253,7 +253,8 @@ class TTSModel(nn.Module):
                 If neither `config` nor `language` is provided, defaults to `"english", which is the same model as 'english_2026-04'`.
             config: A path to a custom YAML config file saved locally (e.g., `"C://pocket_tts/pocket_tts_config.yaml"`).
             temp: Sampling temperature for generation. Higher values produce more
-                diverse but potentially lower quality output.
+                diverse but potentially lower quality output. If None, defaults to
+                the language's tuned value (0.3 for English, 0.7 otherwise).
             lsd_decode_steps: Number of steps for Lagrangian Self Distillation
                 decoding. More steps can improve quality but increase computation.
             noise_clamp: Maximum value for noise sampling. If None, no clamping
@@ -292,6 +293,8 @@ class TTSModel(nn.Module):
             )
         if config is None and language is None:
             language = DEFAULT_LANGUAGE
+        if temp is None:
+            temp = get_default_temperature_for_language(language)
         if language is not None:
             if language == "french":
                 raise ValueError(

--- a/pocket_tts/utils/config.py
+++ b/pocket_tts/utils/config.py
@@ -116,6 +116,7 @@ class Config(StrictModel):
     pad_with_spaces_for_short_inputs: bool = False
     remove_semicolons: bool = False
     model_recommended_frames_after_eos: int | None = None
+    default_temperature: float = 0.7
 
 
 def load_config(yaml_path: str | Path) -> Config:


### PR DESCRIPTION
## Motivation

Human evaluations consistently prefer the English model at temperature **0.3** over the current default **0.7**, and the change is free on every objective axis we measured.

**Dedicated head-to-head studies** (all judgments on this single comparison, crowd-sourced raters, LibriSpeech test-clean prompts):

| study | judgments | temp 0.3 | temp 0.7 |
|---|---|---|---|
| Perceived audio quality | 400 | **214 wins (53.5%)**, Elo 2010 [1986, 2032] | 186, Elo 1985 [1959, 2009] |
| Voice similarity (vs reference) | 300 | **158 wins (52.7%)**, Elo 2009 [1981, 2035] | 142, Elo 1990 [1961, 2018] |

An earlier 4-condition quality study (400 judgments shared across 6 pairs) showed the same direction (+29 Elo for 0.3). The preference is modest but reproduced across independent studies, and no study favors 0.7 on any axis.

**Objective metrics** (full 1127-utterance offline eval, granite ASR, 5 independent runs per cell, mean ± sd):

| | temp 0.3 | temp 0.7 |
|---|---|---|
| WER (whisper-normalized) | **0.82 ± 0.02%** | 0.92 ± 0.04% |
| UTMOS | **4.358 ± 0.004** | 4.318 ± 0.005 |
| speaker similarity (WavLM) | 0.503 ± 0.001 | 0.504 ± 0.001 |
| speech rate | 3.25 w/s | 3.30 w/s |

The WER difference is significant (non-overlapping 95% CIs): 0.3 is slightly *more* intelligible as well.

## Change

- `DEFAULT_TEMPERATURE_FOR_LANGUAGE = {"english": 0.3}` with a resolver mirroring the existing per-language voice/text defaults; all other languages keep 0.7 (untested at 0.3).
- `TTSModel.load_model(temp=None)` and `--temperature` now default to the language's tuned value; explicit values override as before.
- Docs updated.

Note: the `english` substring match also covers `english_2026-01`; the evals were run on the current default English model (`english_2026-04`). Happy to pin it to specific configs if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUch6sYtThkymAUpbTHfuS
