### PR TITLE
Fix docker compose command duplicating entrypoint args

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     volumes:
       - pocket_tts_cache:/root/.cache/pocket_tts
       - hf_cache:/root/.cache/huggingface
-    command: ["uv", "run", "pocket-tts", "serve", "--host", "0.0.0.0"]
+    command: ["serve", "--host", "0.0.0.0"]
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
## docker-compose command duplicates ENTRYPOINT args, causing "No such command uv" error

When running `docker compose up`, the container fails with:

```
...
pocket-tts-1  | ╭─ Error ─────────────────────────────────────────────╮
pocket-tts-1  | │ No such command 'uv'.                                │
pocket-tts-1  | ╰──────────────────────────────────────────────────────╯

**Root cause:** The Dockerfile sets `ENTRYPOINT ["uv", "run", "pocket-tts"]` and docker-compose.yaml sets `command: ["uv", "run", "pocket-tts", "serve", "--host", "0.0.0.0"]`. Docker appends the command to the entrypoint, so the actual process becomes:

uv run pocket-tts uv run pocket-tts serve --host 0.0.0.0

The second `uv` is passed as a subcommand to `pocket-tts`, which doesn't exist.

**Fix:** Remove `uv run pocket-tts` from the compose `command`, since the ENTRYPOINT already provides it:
```

```yaml
command: ["serve", "--host", "0.0.0.0"]