### PR TITLE
Question: should audio_read handle non-16-bit WAV voice prompts?

### DIFF
--- a/pocket_tts/data/audio.py
+++ b/pocket_tts/data/audio.py
@@ -20,27 +20,55 @@ logger = logging.getLogger(__name__)
 FIRST_CHUNK_LENGTH_SECONDS = float(os.environ.get("FIRST_CHUNK_LENGTH_SECONDS", "0"))
 
 
-def audio_read(filepath: str | Path) -> tuple[torch.Tensor, int]:
-    """Read audio file. WAV uses built-in wave module; other formats require soundfile."""
-    filepath = Path(filepath)
+# Integer PCM sample widths, in bytes, that map directly onto a numpy dtype.
+# 24-bit (3 bytes) has no numpy equivalent and is handled separately.
+_PCM_DTYPES = {1: np.uint8, 2: "<i2", 4: "<i4"}
 
-    if filepath.suffix.lower() == ".wav":
-        # Use built-in wave module for WAV files
-        with wave.open(str(filepath), "rb") as wav_file:
-            sample_rate = wav_file.getframerate()
-            n_channels = wav_file.getnchannels()
-            raw_data = wav_file.readframes(-1)
-            samples = np.frombuffer(raw_data, dtype=np.int16).astype(np.float32) / 32768.0
-            if n_channels > 1:
-                samples = samples.reshape(-1, n_channels).mean(axis=1)
-            return torch.from_numpy(samples).unsqueeze(0), sample_rate
 
-    # For non-WAV formats, use soundfile (optional dependency)
+def _decode_pcm(raw_data: bytes, sample_width: int) -> np.ndarray:
+    """Decode little-endian integer PCM bytes to float32 samples in [-1, 1]."""
+    usable = len(raw_data) - len(raw_data) % sample_width
+    raw_data = raw_data[:usable]
+
+    if sample_width == 3:
+        # No 24-bit numpy dtype exists, so widen each sample to 32 bits by
+        # padding the low-order byte, which preserves both value and sign.
+        as_bytes = np.frombuffer(raw_data, dtype=np.uint8).reshape(-1, 3)
+        widened = np.zeros((as_bytes.shape[0], 4), dtype=np.uint8)
+        widened[:, 1:] = as_bytes
+        samples = widened.view("<i4").reshape(-1)
+        return samples.astype(np.float32) / 2147483648.0
+
+    samples = np.frombuffer(raw_data, dtype=_PCM_DTYPES[sample_width])
+    if sample_width == 1:
+        # 8-bit WAV is the odd one out: unsigned, centered on 128.
+        return (samples.astype(np.float32) - 128.0) / 128.0
+    return samples.astype(np.float32) / float(2 ** (8 * sample_width - 1))
+
+
+def _read_wav_with_stdlib(filepath: Path) -> tuple[torch.Tensor, int]:
+    """Read an integer-PCM WAV file using the standard library only."""
+    with wave.open(str(filepath), "rb") as wav_file:
+        sample_rate = wav_file.getframerate()
+        n_channels = wav_file.getnchannels()
+        sample_width = wav_file.getsampwidth()
+        if sample_width not in (1, 2, 3, 4):
+            raise wave.Error(f"unsupported sample width: {sample_width} bytes")
+        raw_data = wav_file.readframes(-1)
+
+    samples = _decode_pcm(raw_data, sample_width)
+    if n_channels > 1:
+        samples = samples[: len(samples) - len(samples) % n_channels]
+        samples = samples.reshape(-1, n_channels).mean(axis=1)
+    return torch.from_numpy(samples).unsqueeze(0), sample_rate
+
+
+def _read_with_soundfile(filepath: Path) -> tuple[torch.Tensor, int]:
     try:
         import soundfile as sf
     except ImportError as e:
         raise ImportError(
-            "soundfile is required to read non-WAV audio files. "
+            f"soundfile is required to read {filepath.name}. "
             "Install with: `pip install soundfile` or `uvx --with soundfile`"
         ) from e
 
@@ -50,6 +78,21 @@ def audio_read(filepath: str | Path) -> tuple[torch.Tensor, int]:
     else:
         wav = torch.from_numpy(data.mean(axis=1)).unsqueeze(0)
     return wav, sample_rate
+
+
+def audio_read(filepath: str | Path) -> tuple[torch.Tensor, int]:
+    """Read audio file. WAV uses built-in wave module; other formats require soundfile."""
+    filepath = Path(filepath)
+
+    if filepath.suffix.lower() == ".wav":
+        try:
+            return _read_wav_with_stdlib(filepath)
+        except wave.Error:
+            # The stdlib only handles plain integer PCM. Float-encoded and
+            # WAVE_FORMAT_EXTENSIBLE files still work through soundfile.
+            logger.debug("Falling back to soundfile for %s", filepath)
+
+    return _read_with_soundfile(filepath)
 
 
 class StreamingWAVWriter:

--- a/tests/test_audio_read.py
+++ b/tests/test_audio_read.py
@@ -1,0 +1,77 @@
+import wave
+
+import numpy as np
+import pytest
+
+from pocket_tts.data.audio import audio_read
+
+SAMPLE_RATE = 24000
+
+
+def make_signal(n_samples: int = 4096) -> np.ndarray:
+    """A sine sweep, kept just below full scale so no width clips it."""
+    t = np.arange(n_samples, dtype=np.float64) / SAMPLE_RATE
+    return 0.9 * np.sin(2 * np.pi * 440 * t * (1 + t))
+
+
+def write_wav(path, signal: np.ndarray, sample_width: int, n_channels: int = 1):
+    if n_channels > 1:
+        signal = np.repeat(signal, n_channels)
+
+    if sample_width == 1:
+        raw = np.clip(signal * 128.0 + 128.0, 0, 255).astype(np.uint8).tobytes()
+    elif sample_width == 3:
+        scaled = np.clip(signal * 2147483648.0, -(2**31), 2**31 - 1).astype("<i4")
+        # Drop the low-order byte to get 24-bit little-endian samples.
+        raw = scaled.view(np.uint8).reshape(-1, 4)[:, 1:].tobytes()
+    else:
+        limit = 2 ** (8 * sample_width - 1)
+        dtype = "<i2" if sample_width == 2 else "<i4"
+        raw = np.clip(signal * limit, -limit, limit - 1).astype(dtype).tobytes()
+
+    with wave.open(str(path), "wb") as f:
+        f.setnchannels(n_channels)
+        f.setsampwidth(sample_width)
+        f.setframerate(SAMPLE_RATE)
+        f.writeframes(raw)
+
+
+@pytest.mark.parametrize("sample_width", [1, 2, 3, 4])
+def test_reads_every_pcm_bit_depth(tmp_path, sample_width):
+    signal = make_signal()
+    path = tmp_path / f"tone_{sample_width * 8}bit.wav"
+    write_wav(path, signal, sample_width)
+
+    wav, sample_rate = audio_read(path)
+
+    assert sample_rate == SAMPLE_RATE
+    assert wav.shape == (1, len(signal))
+    # 8-bit quantization is coarse; the wider depths should be near-exact.
+    tolerance = 1 / 128 if sample_width == 1 else 1e-4
+    assert np.allclose(wav.numpy()[0], signal, atol=tolerance)
+
+
+@pytest.mark.parametrize("sample_width", [2, 3])
+def test_downmixes_stereo_to_mono(tmp_path, sample_width):
+    signal = make_signal(1024)
+    path = tmp_path / f"stereo_{sample_width * 8}bit.wav"
+    write_wav(path, signal, sample_width, n_channels=2)
+
+    wav, _ = audio_read(path)
+
+    assert wav.shape == (1, len(signal))
+    assert np.allclose(wav.numpy()[0], signal, atol=1e-4)
+
+
+def test_falls_back_to_soundfile_for_float_wav(tmp_path):
+    """Float WAVs are rejected by the wave module but readable via soundfile."""
+    sf = pytest.importorskip("soundfile")
+
+    signal = make_signal(1024)
+    path = tmp_path / "float32.wav"
+    sf.write(str(path), signal.astype(np.float32), SAMPLE_RATE, subtype="FLOAT")
+
+    wav, sample_rate = audio_read(path)
+
+    assert sample_rate == SAMPLE_RATE
+    assert np.allclose(wav.numpy()[0], signal, atol=1e-6)


### PR DESCRIPTION
**Heads up: this PR was written with AI assistance (Claude Code). I reviewed the change and ran the tests locally, but please review it with that in mind.**

I hit this with my own recordings and I am genuinely unsure whether it is a bug or a deliberate trade-off, so treat this as a proposal rather than a bug report. Happy to close it, shrink it, or turn it into an issue instead.

## What I observed

`audio_read` decodes every WAV as 16-bit PCM regardless of the file's actual sample width:

```python
samples = np.frombuffer(raw_data, dtype=np.int16).astype(np.float32) / 32768.0
```

Feeding it 24-bit recordings (what my recorder produces by default) gave one of two outcomes:

- `ValueError: buffer size must be a multiple of element size`, when the byte count is odd for int16
- silently decoded noise, when the byte count happens to be even

The first is easy to diagnose. The second is what prompted this PR: the garbage is accepted as a voice prompt and encoded without any error, so `export-voice` writes a `.safetensors` full of noise and `generate` happily produces output from it. I only noticed because one of three same-session takes "succeeded" and sounded wrong. Same path affects uploads to the `serve` web UI, where it surfaces as a 500 with no detail.

## Why this may be intended

The stdlib-only WAV path looks deliberate, keeping `soundfile` an optional dependency for the common case, and 16-bit is what most voice samples are. If that trade-off is intentional then most of this PR is unnecessary, and the smaller fix would be to raise a clear error on unsupported sample widths, or route them to `soundfile`, rather than adding decoders.

I could not find an existing issue for this, so I have no idea whether it affects anyone else or just my recording setup. #189 looked similar (cloning noise, built-in voices fine) but turned out to be a sample-rate problem.

## What this PR does, if the behaviour is unintended

- Respects `wav_file.getsampwidth()` and decodes 8, 16, 24, and 32-bit integer PCM. 8-bit is treated as unsigned centered on 128; 24-bit is widened to int32 by padding the low-order byte, preserving value and sign.
- Falls back to `soundfile` for files the `wave` module cannot parse at all (IEEE float, `WAVE_FORMAT_EXTENSIBLE`) instead of propagating `wave.Error`.
- Leaves the 16-bit path unchanged, so the common case keeps the same stdlib-only behaviour.

Happy to reduce this to just the error-on-unsupported-width version if you would prefer to keep the decoder surface small.

## Tests

Added `tests/test_audio_read.py`: round-trips a sine sweep through all four bit depths, checks stereo downmix at 16 and 24-bit, and covers the float-WAV fallback (skipped when `soundfile` is absent).

Verified against a real 24-bit recording: it now decodes bit-identically to a 16-bit conversion of the same file (peak 0.38521 vs 0.38522).

`uv run pytest -n 3` passes, 41 tests.