### PR TITLE
Mimi: decode_from_latent owns quantizer + transposes; encode_to_latent returns [B, T, C]

### DIFF
--- a/pocket_tts/models/mimi.py
+++ b/pocket_tts/models/mimi.py
@@ -87,7 +87,9 @@ class MimiModel(nn.Module):
         raise NotImplementedError()
 
     def decode_from_latent(self, latent: torch.Tensor, mimi_state) -> torch.Tensor:
-        latent = self.quantizer(latent)
+        """Decodes [B, T, C] quantizer-space latents (as produced by
+        encode_to_latent or the flow LM) back to audio."""
+        latent = self.quantizer(latent.transpose(-1, -2))
         emb = self._to_encoder_framerate(latent, mimi_state)
         (emb,) = self.decoder_transformer(emb, mimi_state)
         out = self.decoder(emb, mimi_state)
@@ -101,7 +103,7 @@ class MimiModel(nn.Module):
             x (torch.Tensor): Float tensor of shape [B, C, T].
 
         Returns:
-            Unquantized embeddings.
+            Unquantized embeddings of shape [B, T, C].
         """
         assert x.dim() == 3, (
             f"CompressionModel._encode_to_unquantized_latent expects audio of shape [B, C, T] but got {x.shape}"
@@ -117,4 +119,4 @@ class MimiModel(nn.Module):
 
         (emb,) = self.encoder_transformer(emb, model_state=None)
         emb = self._to_framerate(emb)
-        return emb
+        return emb.transpose(-1, -2)

--- a/pocket_tts/models/mimi.py
+++ b/pocket_tts/models/mimi.py
@@ -87,6 +87,7 @@ class MimiModel(nn.Module):
         raise NotImplementedError()
 
     def decode_from_latent(self, latent: torch.Tensor, mimi_state) -> torch.Tensor:
+        latent = self.quantizer(latent)
         emb = self._to_encoder_framerate(latent, mimi_state)
         (emb,) = self.decoder_transformer(emb, mimi_state)
         out = self.decoder(emb, mimi_state)

--- a/pocket_tts/models/tts_model.py
+++ b/pocket_tts/models/tts_model.py
@@ -372,11 +372,7 @@ class TTSModel(nn.Module):
 
     def _decode_and_dump(self, encoded: torch.Tensor, filename: str):
         mimi_state = init_states(self.mimi, batch_size=1, sequence_length=10000)
-        if encoded.shape[1] == self.mimi.quantizer.dimension:
-            latent_to_decode = self.mimi.quantizer(encoded)
-        else:
-            latent_to_decode = encoded
-        resored_audio = self.mimi.decode_from_latent(latent_to_decode, mimi_state)
+        resored_audio = self.mimi.decode_from_latent(encoded, mimi_state)
         scipy.io.wavfile.write(filename, self.sample_rate, resored_audio.numpy())
         logger.info("Saved restored audio from Mimi encoding to %s for debugging", filename)
 
@@ -452,10 +448,9 @@ class TTSModel(nn.Module):
                     break
                 mimi_decoding_input = latent * self.flow_lm.emb_std + self.flow_lm.emb_mean
                 transposed = mimi_decoding_input.transpose(-1, -2)
-                quantized = self.mimi.quantizer(transposed)
 
                 t = time.monotonic()
-                audio_frame = self.mimi.decode_from_latent(quantized, mimi_state)
+                audio_frame = self.mimi.decode_from_latent(transposed, mimi_state)
                 increment_steps(self.mimi, mimi_state, increment=mimi_steps_per_latent)
                 audio_frame_duration = audio_frame.shape[2] / self.config.mimi.sample_rate
                 # We could log the timings here.

--- a/pocket_tts/models/tts_model.py
+++ b/pocket_tts/models/tts_model.py
@@ -383,7 +383,7 @@ class TTSModel(nn.Module):
             # sanity check
             self._decode_and_dump(encoded, "debug_encoded_latent_decoded.wav")
 
-        latents = encoded.transpose(-1, -2).to(torch.float32)
+        latents = encoded.to(torch.float32)
         conditioning = F.linear(latents, self.flow_lm.speaker_proj_weight)
         return conditioning
 
@@ -447,10 +447,9 @@ class TTSModel(nn.Module):
                 if latent is None:
                     break
                 mimi_decoding_input = latent * self.flow_lm.emb_std + self.flow_lm.emb_mean
-                transposed = mimi_decoding_input.transpose(-1, -2)
 
                 t = time.monotonic()
-                audio_frame = self.mimi.decode_from_latent(transposed, mimi_state)
+                audio_frame = self.mimi.decode_from_latent(mimi_decoding_input, mimi_state)
                 increment_steps(self.mimi, mimi_state, increment=mimi_steps_per_latent)
                 audio_frame_duration = audio_frame.shape[2] / self.config.mimi.sample_rate
                 # We could log the timings here.


### PR DESCRIPTION
decode_from_latent always needs the quantizer projection and every caller works in time-major [B, T, C] — so both the projection and the transposes move inside Mimi:

- `decode_from_latent` takes [B, T, C] quantizer-space latents (as the flow LM produces) and owns `quantizer(...)` + the transpose; the shape-`if` at the debug call site (whose else branch never ran) is gone.
- `encode_to_latent` returns [B, T, C], deleting the compensating transpose at its call site.

Test suite passes (43/43, including audio round-trips) at each step.