### PR TITLE
Add pause support to text input via [pause] and SSML <break>

### DIFF
--- a/pocket_tts/default_parameters.py
+++ b/pocket_tts/default_parameters.py
@@ -7,6 +7,12 @@ DEFAULT_FRAMES_AFTER_EOS = None
 # TODO: make this dynamic since english_2026-04 supports bigger chunks
 MAX_TOKEN_PER_CHUNK = 50
 
+# Pause markers in the text input, e.g. "Wait. [pause:1.5] Now listen."
+# A bare "[pause]" uses DEFAULT_PAUSE_SECONDS. Durations are clamped to
+# MAX_PAUSE_SECONDS so a typo cannot generate hours of silence.
+DEFAULT_PAUSE_SECONDS = 0.5
+MAX_PAUSE_SECONDS = 10.0
+
 DEFAULT_TEXT_FOR_LANGUAGE = {
     "english": (
         "Hello world. I am Kyutai's Pocket TTS. "

--- a/pocket_tts/models/tts_model.py
+++ b/pocket_tts/models/tts_model.py
@@ -3,6 +3,7 @@ import logging
 import math
 import os
 import queue
+import re
 import statistics
 import threading
 import time
@@ -26,6 +27,8 @@ from pocket_tts.default_parameters import (
     DEFAULT_LANGUAGE,
     DEFAULT_LSD_DECODE_STEPS,
     DEFAULT_NOISE_CLAMP,
+    DEFAULT_PAUSE_SECONDS,
+    MAX_PAUSE_SECONDS,
     MAX_TOKEN_PER_CHUNK,
 )
 from pocket_tts.models.flow_lm import FlowLMModel
@@ -601,32 +604,47 @@ class TTSModel(nn.Module):
         if frames_after_eos is None:
             frames_after_eos = self.model_recommended_frames_after_eos
 
-        # This is a very simplistic way of handling long texts. We could do much better
-        # by using teacher forcing, but it would be a bit slower.
-        # TODO: add the teacher forcing method for long texts where we use the audio of one chunk
-        # as conditioning for the next chunk.
-        chunks = split_into_best_sentences(
-            self.flow_lm.conditioner.tokenizer,
-            text_to_generate,
-            max_tokens,
-            self.pad_with_spaces_for_short_inputs,
-            remove_semicolons=self.remove_semicolons,
-        )
+        # Pause markers are handled before anything else, because
+        # prepare_text_prompt would otherwise capitalise and punctuate them.
+        parts = split_on_pauses(text_to_generate)
+        if not parts:
+            raise ValueError("Text prompt cannot be empty")
 
-        for chunk in chunks:
-            text_to_generate, frames_after_eos_guess = prepare_text_prompt(
-                chunk, self.pad_with_spaces_for_short_inputs, self.remove_semicolons
+        for part in parts:
+            if isinstance(part, float):
+                yield self._silence(part)
+                continue
+
+            # This is a very simplistic way of handling long texts. We could do much better
+            # by using teacher forcing, but it would be a bit slower.
+            # TODO: add the teacher forcing method for long texts where we use the audio of one
+            # chunk as conditioning for the next chunk.
+            chunks = split_into_best_sentences(
+                self.flow_lm.conditioner.tokenizer,
+                part,
+                max_tokens,
+                self.pad_with_spaces_for_short_inputs,
+                remove_semicolons=self.remove_semicolons,
             )
-            frames_after_eos_guess += 2
-            effective_frames = (
-                frames_after_eos if frames_after_eos is not None else frames_after_eos_guess
-            )
-            yield from self._generate_audio_stream_short_text(
-                model_state=model_state,
-                text_to_generate=text_to_generate,
-                frames_after_eos=effective_frames,
-                copy_state=copy_state,
-            )
+
+            for chunk in chunks:
+                prompt, frames_after_eos_guess = prepare_text_prompt(
+                    chunk, self.pad_with_spaces_for_short_inputs, self.remove_semicolons
+                )
+                frames_after_eos_guess += 2
+                effective_frames = (
+                    frames_after_eos if frames_after_eos is not None else frames_after_eos_guess
+                )
+                yield from self._generate_audio_stream_short_text(
+                    model_state=model_state,
+                    text_to_generate=prompt,
+                    frames_after_eos=effective_frames,
+                    copy_state=copy_state,
+                )
+
+    def _silence(self, seconds: float) -> torch.Tensor:
+        """Silent audio, shaped like the chunks generate_audio_stream yields."""
+        return torch.zeros(int(round(seconds * self.sample_rate)), dtype=torch.float32)
 
     @torch.no_grad
     def _generate_audio_stream_short_text(
@@ -907,6 +925,126 @@ class TTSModel(nn.Module):
         gen_len_sec = token_count / self._TOKENS_PER_SECOND_ESTIMATE + self._GEN_SECONDS_PADDING
         frame_rate = self.config.mimi.frame_rate
         return math.ceil(gen_len_sec * frame_rate)
+
+
+# SSML <break strength="..."/> values, in seconds. The spec defines the names
+# but not the durations; these are the conventional mappings used by other
+# engines.
+SSML_BREAK_STRENGTHS = {
+    "none": 0.0,
+    "x-weak": 0.1,
+    "weak": 0.25,
+    "medium": 0.5,
+    "strong": 0.75,
+    "x-strong": 1.0,
+}
+
+# Either the shorthand "[pause]" / "[pause:1.5]" or an SSML "<break .../>".
+PAUSE_PATTERN = re.compile(
+    r"""
+      \[\s*pause\s*(?::\s*(?P<shorthand>[0-9]*\.?[0-9]+)\s*)?\]
+    | <\s*break\b(?P<attrs>[^>]*?)/?\s*>
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+_SPEAK_TAG = re.compile(r"</?\s*speak\b[^>]*>", re.IGNORECASE)
+_CLOSING_BREAK = re.compile(r"</\s*break\s*>", re.IGNORECASE)
+_ANY_TAG = re.compile(r"<\s*/?\s*([a-zA-Z][\w-]*)\b[^>]*>")
+_BREAK_TIME = re.compile(r"""time\s*=\s*["']?\s*([0-9]*\.?[0-9]+)\s*(ms|s)\b""", re.IGNORECASE)
+_BREAK_STRENGTH = re.compile(r"""strength\s*=\s*["']?\s*([a-zA-Z-]+)""", re.IGNORECASE)
+
+
+def _break_seconds(attrs: str, default_seconds: float) -> float:
+    """Read the duration out of a <break> tag's attributes."""
+    time_match = _BREAK_TIME.search(attrs)
+    if time_match is not None:
+        value = float(time_match.group(1))
+        return value / 1000.0 if time_match.group(2).lower() == "ms" else value
+
+    strength_match = _BREAK_STRENGTH.search(attrs)
+    if strength_match is not None:
+        name = strength_match.group(1).lower()
+        if name not in SSML_BREAK_STRENGTHS:
+            raise ValueError(
+                f"Unknown <break strength='{name}'>. "
+                f"Valid values: {', '.join(SSML_BREAK_STRENGTHS)}."
+            )
+        return SSML_BREAK_STRENGTHS[name]
+
+    return default_seconds
+
+
+def split_on_pauses(
+    text: str,
+    default_seconds: float = DEFAULT_PAUSE_SECONDS,
+    max_seconds: float = MAX_PAUSE_SECONDS,
+) -> list[str | float]:
+    """Split text on pause markers into speakable text and silences.
+
+    Two syntaxes are accepted, and they can be mixed freely:
+
+    ==========================  ========================================
+    ``[pause]``                 ``default_seconds`` of silence
+    ``[pause:1.5]``             1.5 seconds
+    ``<break time="500ms"/>``   0.5 seconds (SSML)
+    ``<break time="2s"/>``      2 seconds (SSML)
+    ``<break strength="weak"/>``  see :data:`SSML_BREAK_STRENGTHS`
+    ``<break/>``                ``default_seconds``
+    ==========================  ========================================
+
+    A surrounding ``<speak>`` wrapper is stripped, since real SSML documents
+    have one. Any *other* SSML tag raises ``ValueError`` rather than being
+    dropped or read aloud - pocket-tts cannot do prosody, emphasis or phonemes,
+    and silently ignoring those tags would produce quietly wrong output.
+
+    Durations are clamped to ``max_seconds``.
+
+    Returns a list whose items are either ``str`` (speak this) or ``float``
+    (stay silent for this many seconds). Text with no markers returns a
+    single-element list, so existing callers are unaffected.
+
+        >>> split_on_pauses("Ready. [pause:1.5] Go.")
+        ['Ready. ', 1.5, ' Go.']
+        >>> split_on_pauses('Ready. <break time="1.5s"/> Go.')
+        ['Ready. ', 1.5, ' Go.']
+    """
+    text = _SPEAK_TAG.sub("", text)
+    text = _CLOSING_BREAK.sub("", text)
+
+    unsupported = {
+        m.group(1).lower() for m in _ANY_TAG.finditer(text) if m.group(1).lower() != "break"
+    }
+    if unsupported:
+        listed = ", ".join(f"<{name}>" for name in sorted(unsupported))
+        raise ValueError(
+            f"Unsupported SSML tag(s): {listed}. Pocket TTS supports <break> only "
+            f"(and an optional <speak> wrapper); remove the others."
+        )
+
+    parts: list[str | float] = []
+    cursor = 0
+
+    for match in PAUSE_PATTERN.finditer(text):
+        before = text[cursor : match.start()]
+        if before.strip():
+            parts.append(before)
+
+        if match.group("shorthand") is not None:
+            seconds = float(match.group("shorthand"))
+        elif match.group("attrs") is not None:
+            seconds = _break_seconds(match.group("attrs"), default_seconds)
+        else:
+            seconds = default_seconds
+
+        parts.append(min(max(seconds, 0.0), max_seconds))
+        cursor = match.end()
+
+    tail = text[cursor:]
+    if tail.strip():
+        parts.append(tail)
+
+    return parts
 
 
 def prepare_text_prompt(

--- a/tests/test_pauses.py
+++ b/tests/test_pauses.py
@@ -1,0 +1,174 @@
+import pytest
+
+from pocket_tts.default_parameters import DEFAULT_PAUSE_SECONDS, MAX_PAUSE_SECONDS
+from pocket_tts.models.tts_model import SSML_BREAK_STRENGTHS, split_on_pauses
+
+# --------------------------------------------------------------- no markers
+
+
+def test_text_without_markers_is_returned_unchanged():
+    assert split_on_pauses("Hello world.") == ["Hello world."]
+
+
+def test_empty_text_returns_nothing_to_say():
+    assert split_on_pauses("") == []
+    assert split_on_pauses("   ") == []
+
+
+# --------------------------------------------------------- [pause] shorthand
+
+
+def test_bare_marker_uses_the_default_duration():
+    assert split_on_pauses("Ready. [pause] Go.") == ["Ready. ", DEFAULT_PAUSE_SECONDS, " Go."]
+
+
+def test_explicit_duration_is_used():
+    assert split_on_pauses("Ready. [pause:1.5] Go.") == ["Ready. ", 1.5, " Go."]
+
+
+def test_shorthand_is_case_insensitive_and_tolerates_spaces():
+    assert split_on_pauses("A [PAUSE: 2] B") == ["A ", 2.0, " B"]
+    assert split_on_pauses("A [ pause ] B") == ["A ", DEFAULT_PAUSE_SECONDS, " B"]
+
+
+def test_decimal_without_leading_zero():
+    assert split_on_pauses("A [pause:.25] B") == ["A ", 0.25, " B"]
+
+
+def test_malformed_shorthand_is_left_as_text():
+    # Must stay in the spoken text rather than silently disappearing.
+    assert split_on_pauses("A [pause:] B") == ["A [pause:] B"]
+    assert split_on_pauses("A [paws:1] B") == ["A [paws:1] B"]
+    assert split_on_pauses("A [pause 1] B") == ["A [pause 1] B"]
+
+
+# ------------------------------------------------------------- SSML <break>
+
+
+def test_break_with_milliseconds():
+    assert split_on_pauses('Ready. <break time="500ms"/> Go.') == ["Ready. ", 0.5, " Go."]
+
+
+def test_break_with_seconds():
+    assert split_on_pauses('Ready. <break time="1.5s"/> Go.') == ["Ready. ", 1.5, " Go."]
+
+
+def test_bare_break_uses_the_default_duration():
+    assert split_on_pauses("A <break/> B") == ["A ", DEFAULT_PAUSE_SECONDS, " B"]
+    assert split_on_pauses("A <break /> B") == ["A ", DEFAULT_PAUSE_SECONDS, " B"]
+    assert split_on_pauses("A <break> B") == ["A ", DEFAULT_PAUSE_SECONDS, " B"]
+
+
+def test_break_open_close_pair_is_one_pause():
+    assert split_on_pauses("A <break></break> B") == ["A ", DEFAULT_PAUSE_SECONDS, " B"]
+
+
+@pytest.mark.parametrize("name,seconds", sorted(SSML_BREAK_STRENGTHS.items()))
+def test_break_strength_values(name, seconds):
+    assert split_on_pauses(f'A <break strength="{name}"/> B') == ["A ", seconds, " B"]
+
+
+def test_break_single_quotes_and_loose_spacing():
+    assert split_on_pauses("A <break  time = '250ms' /> B") == ["A ", 0.25, " B"]
+
+
+def test_break_is_case_insensitive():
+    assert split_on_pauses('A <BREAK TIME="1s"/> B') == ["A ", 1.0, " B"]
+
+
+def test_time_wins_over_strength_when_both_are_given():
+    assert split_on_pauses('A <break time="2s" strength="weak"/> B') == ["A ", 2.0, " B"]
+
+
+def test_unknown_strength_is_an_error():
+    with pytest.raises(ValueError, match="Unknown <break strength"):
+        split_on_pauses('A <break strength="enormous"/> B')
+
+
+# ------------------------------------------------------------ SSML document
+
+
+def test_speak_wrapper_is_stripped():
+    ssml = '<speak>Ready. <break time="1s"/> Go.</speak>'
+    assert split_on_pauses(ssml) == ["Ready. ", 1.0, " Go."]
+
+
+def test_speak_wrapper_with_attributes_is_stripped():
+    ssml = '<speak version="1.1" xml:lang="en-US">Hi <break/> there</speak>'
+    assert split_on_pauses(ssml) == ["Hi ", DEFAULT_PAUSE_SECONDS, " there"]
+
+
+def test_other_ssml_tags_raise_rather_than_being_ignored():
+    # Silently dropping these would produce quietly wrong audio.
+    with pytest.raises(ValueError, match="<prosody>"):
+        split_on_pauses('<speak><prosody rate="slow">Slow</prosody></speak>')
+
+    with pytest.raises(ValueError, match="Unsupported SSML tag"):
+        split_on_pauses("Hello <emphasis>world</emphasis>")
+
+
+def test_error_lists_every_unsupported_tag():
+    with pytest.raises(ValueError) as excinfo:
+        split_on_pauses("<emphasis>a</emphasis> <prosody>b</prosody>")
+    message = str(excinfo.value)
+    assert "<emphasis>" in message and "<prosody>" in message
+
+
+def test_comparison_operators_are_not_mistaken_for_tags():
+    assert split_on_pauses("5 < 6 and 7 > 3.") == ["5 < 6 and 7 > 3."]
+
+
+# ------------------------------------------------------------------- mixing
+
+
+def test_both_syntaxes_can_be_mixed():
+    assert split_on_pauses('One [pause:1] two <break time="2s"/> three') == [
+        "One ",
+        1.0,
+        " two ",
+        2.0,
+        " three",
+    ]
+
+
+def test_several_markers_in_one_string():
+    assert split_on_pauses("One [pause:1] two [pause:2] three") == [
+        "One ",
+        1.0,
+        " two ",
+        2.0,
+        " three",
+    ]
+
+
+def test_marker_at_the_start_and_end():
+    assert split_on_pauses("[pause:1] hi [pause:2]") == [1.0, " hi ", 2.0]
+
+
+def test_adjacent_markers_do_not_produce_empty_text():
+    parts = split_on_pauses('Hi [pause:1]<break time="2s"/> there')
+    assert parts == ["Hi ", 1.0, 2.0, " there"]
+    assert all(not isinstance(p, str) or p.strip() for p in parts)
+
+
+def test_only_a_marker_yields_only_silence():
+    assert split_on_pauses("[pause:1]") == [1.0]
+    assert split_on_pauses('<break time="1s"/>') == [1.0]
+
+
+# ------------------------------------------------------------------ clamping
+
+
+def test_duration_is_clamped_to_the_maximum():
+    assert split_on_pauses("A [pause:9999] B") == ["A ", MAX_PAUSE_SECONDS, " B"]
+    assert split_on_pauses('A <break time="9999s"/> B') == ["A ", MAX_PAUSE_SECONDS, " B"]
+
+
+def test_zero_duration_is_allowed():
+    assert split_on_pauses("A [pause:0] B") == ["A ", 0.0, " B"]
+    assert split_on_pauses('A <break time="0ms"/> B') == ["A ", 0.0, " B"]
+
+
+def test_limits_are_configurable_per_call():
+    assert split_on_pauses("A [pause] B", default_seconds=3.0) == ["A ", 3.0, " B"]
+    assert split_on_pauses("A [pause:99] B", max_seconds=20.0) == ["A ", 20.0, " B"]


### PR DESCRIPTION
Closes #6.

Opening this as a **draft** because the syntax is the part you're most likely to
have an opinion on, and I'd rather change it now than after review. Everything
else is done and tested.

## What it does

Two syntaxes, mixable in the same text:

| written | silence |
|---|---|
| `[pause]` | 0.5s (`DEFAULT_PAUSE_SECONDS`) |
| `[pause:1.5]` | 1.5s |
| `<break time="500ms"/>` | 0.5s |
| `<break time="2s"/>` | 2s |
| `<break strength="weak"/>` | 0.25s |
| `<break/>` | 0.5s |

```python
model.generate_audio(voice, "Three. [pause:1] Two. [pause:1] One. [pause:2] Go.")
model.generate_audio(voice, '<speak>Ready. <break time="1.5s"/> Go.</speak>')
```

A surrounding `<speak>` wrapper is stripped. Durations are clamped to
`MAX_PAUSE_SECONDS` (10s), so a typo like `[pause:100]` can't produce minutes of
silence.

## Why both syntaxes

I went back and forth on this, so here's the reasoning — happy to drop either.

**For SSML `<break>`:** it's the actual standard, and anyone arriving from Polly
or Google already has these tags in their text.

**Against it alone:** SSML implies `<prosody>`, `<emphasis>`, `<say-as>` and the
rest, none of which pocket-tts can do. Accepting `<break>` while silently
ignoring the others seemed worse than not supporting SSML at all — someone
pastes a working Polly document and gets quietly wrong audio.

So unsupported tags **raise** rather than being dropped:

```
ValueError: Unsupported SSML tag(s): <prosody>. Pocket TTS supports <break>
only (and an optional <speak> wrapper); remove the others.
```

The shorthand exists for people who aren't coming from SSML and don't want to
type XML. If you'd prefer only one of the two, the parser is one regex and one
function — say which and I'll cut the other.

## Implementation

- `split_on_pauses()` returns a list mixing speakable `str` with `float`
  durations. Text with no markers returns a single-element list, so **existing
  callers are unaffected** — the existing `test_split_sentences.py` passes
  untouched.

- Parsing happens at the top of `generate_audio_stream`, **before**
  `split_into_best_sentences`. This is the only non-obvious part:
  `prepare_text_prompt` capitalises text and appends punctuation, so a marker
  reaching it gets tokenised and read aloud as *"open bracket pause colon one
  point five close bracket"*.

- **Silence never touches the model.** It's `torch.zeros`, spliced into the
  stream — so it costs no generation time, and it's exact. Since each chunk is
  already generated from its own copy of the state, inserting silence between
  chunks doesn't affect prosody either way.

## Testing

44 unit tests in `tests/test_pauses.py` covering both syntaxes, mixing,
clamping, malformed markers, `<speak>` wrappers, and the unsupported-tag error.

Verified against real audio — the silent region matches the requested duration
to within 0.01s:

```
no marker        1.52s audio   longest silence 0.00s
[pause:1.0]      2.44s audio   longest silence 1.00s
[pause:2.0]      3.44s audio   longest silence 2.00s
<break time="1500ms"/>         longest silence 1.50s
```

Full suite: 76 passed. One pre-existing failure
(`test_audio_read_uses_soundfile_for_8_bit_wav`) is unrelated — `soundfile`
isn't installed in my environment.

## Seeing it work

If it's useful for verifying the pauses without running it, there's a short demo
here — the pause section is the poem near the end, where the gaps are audible
and the spoken segment is highlighted as it plays:

https://youtu.be/N1DSGcchhO8

Built while learning this codebase; it's a local web app on top of the library
rather than anything you need to review.

## Open questions

1. **Syntax** — both, or just one? Your call and I'll adjust.
2. **`MAX_PAUSE_SECONDS`** is a module constant. Would you rather it were a
   `TTSModel` parameter so callers can change it without editing the library?
3. Should `<break strength>` map to different durations than the conventional
   ones I used? The SSML spec names the levels but doesn't define seconds.
