### PR TITLE
lsd_scratch: 5s voice prompts, cosine schedule, batch 16 x 4

### DIFF
--- a/training/configs/lsd_scratch.yaml
+++ b/training/configs/lsd_scratch.yaml
@@ -16,7 +16,7 @@ data:
   train_jsonl: data/hifitts2_200h/train_aligned.jsonl
   valid_jsonl: data/hifitts2_200h/valid_aligned.jsonl
   max_duration_sec: 30.0
-  max_voice_prompt_sec: 3.0
+  max_voice_prompt_sec: 5.0
 
 flow:
   type: lsd
@@ -29,15 +29,16 @@ voice_dropout: 0.2
 
 optim:
   lr: 2e-4
-  schedule: constant  # a full-length cosine measures the same; a compressed one does not
+  schedule: cosine
   warmup_steps: 1000
 
 run_dir: runs/lsd_scratch
 # Effective batch (batch_size x GPUs x grad_accum_steps) must reach 64 rows;
 # below that the quality transition arrives late or not at all. These defaults
-# get there on ONE GPU in ~30 GB -- on 8 GPUs set grad_accum_steps: 1.
-batch_size: 8
-grad_accum_steps: 8
+# get there on ONE GPU in ~16 GiB -- on 8 GPUs set batch_size: 8 and
+# grad_accum_steps: 1.
+batch_size: 16
+grad_accum_steps: 4
 max_steps: 400000
 stats_ema_steps: 1000
 ema_decay: 0.999


### PR DESCRIPTION
Aligns the from-scratch recipe with the one the reference teacher was trained with:

- `max_voice_prompt_sec` 3.0 -> 5.0
- `optim.schedule` constant -> cosine
- `batch_size` 8 x `grad_accum_steps` 8 -> 16 x 4

The effective batch is unchanged at 64 rows per optimizer step, so `test_scratch_reaches_the_effective_batch_floor` still holds. Peak memory on one GPU goes from ~10 to ~16 GiB, still inside the 24 GB the README asks for; the comment above `batch_size` is updated to say what to set on 8 GPUs now that the single-GPU default is no longer 8 x 8.

Speed measurements for the README table are re-running against this recipe.