### PR TITLE
lsd_scratch: batch 64 in a single pass by default

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -42,7 +42,8 @@ Now in detail:
 
 Requirements:
 - Linux - we don't provide official support for Windows/Mac training, but will accept bugfix PRs
-- One NVIDIA GPU (24 GB is comfortable at the default batch size); you can use more GPUs to train faster
+- One NVIDIA GPU (the default batch size wants ~56 GB; a consumer GPU runs `batch_size: 16` with
+  `grad_accum_steps: 4` in ~16 GB); you can use more GPUs to train faster
 - Python 3.10+ and [uv](https://docs.astral.sh/uv/)
 - ~60 GB disk per 1,000 hours of prepared audio
 

--- a/training/configs/lsd_scratch.yaml
+++ b/training/configs/lsd_scratch.yaml
@@ -34,11 +34,12 @@ optim:
 
 run_dir: runs/lsd_scratch
 # Effective batch (batch_size x GPUs x grad_accum_steps) must reach 64 rows;
-# below that the quality transition arrives late or not at all. These defaults
-# get there on ONE GPU in ~16 GiB -- on 8 GPUs set batch_size: 8 and
-# grad_accum_steps: 1.
-batch_size: 16
-grad_accum_steps: 4
+# below that the quality transition arrives late or not at all. One GPU in a
+# single pass needs ~56 GiB; if that does not fit, halve batch_size and double
+# grad_accum_steps until it does -- a consumer GPU runs 16 x 4 in ~16 GiB.
+# On 8 GPUs use batch_size: 8.
+batch_size: 64
+grad_accum_steps: 1
 max_steps: 400000
 stats_ema_steps: 1000
 ema_decay: 0.999


### PR DESCRIPTION
`batch_size: 64` with `grad_accum_steps: 1` instead of 16 x 4. The effective batch stays at 64 rows per optimizer step, but hardware that fits them in one pass no longer pays for four.

The comment above `batch_size` now says what to do when they do not fit: halve `batch_size` and double `grad_accum_steps` — a consumer GPU runs 16 x 4 in ~16 GiB. The single-GPU line in the README is updated the same way, since the default now wants ~56 GB rather than fitting in 24.