### PR TITLE
lsd_depth_distill: 64 rows in one pass, drop the unused flow multiplier

### DIFF
--- a/training/configs/lsd_depth_distill.yaml
+++ b/training/configs/lsd_depth_distill.yaml
@@ -20,7 +20,6 @@ flow:
   type: lsd
   kwargs: {}
 
-flow_batch_multiplier: 4
 # No CFG dropout: the teacher's targets are always computed fully-conditioned
 # (both z_cond and z_null come from dropout=False passes), and the student is
 # never run with a null branch at inference. Dropping conditioning here would
@@ -34,8 +33,9 @@ optim:
   warmup_steps: 1000
 
 run_dir: runs/lsd_depth_distill
-batch_size: 16
-max_steps: 200000  # WER/sim reach parity by ~40k, but prosody settles late
+batch_size: 64
+grad_accum_steps: 1
+max_steps: 200000  # WER is at parity by ~50k; sim and UTMOS climb until ~150k
 ema_decay: 0.9999
 log_freq: 50
 valid_freq: 2500


### PR DESCRIPTION
Three things the distill config claimed that were not true.

**`batch_size: 16` -> `64` with `grad_accum_steps: 1`.** 16 rows per optimizer step on a single GPU is a quarter of the floor `lsd_scratch` documents, and the invariant test only enforces that floor for the scratch config. Every depth-distill run behind this recipe used `batch_size: 8` on 8 GPUs, i.e. exactly 64 rows; this is the faithful single-GPU translation.

**Drop `flow_batch_multiplier: 4`.** Distillation returns at `model.py:93`, before `flow_batch_multiplier` is read on line 106: the student regresses onto the teacher's backbone activations and never calls `flow.loss`. The setting does nothing here (which is also why `builders.py` freezes `flow_net` and the LSD weighting net in distill mode), but it reads as though distillation costs 4x the flow work.

**Reword the `max_steps` comment.** It said `WER/sim reach parity by ~40k, but prosody settles late`. From the run it documents:

| step | WER | sim | UTMOS |
|---|---|---|---|
| 25k | 1.69% | 0.896 | 3.862 |
| 50k | 0.93% | 0.906 | 3.970 |
| 100k | 1.33% | 0.907 | 3.974 |
| 150k | 1.32% | 0.925 | 4.234 |

WER is at parity by ~50k, but sim keeps climbing to 150k, so it does not belong with WER. And no prosody metric was recorded in these runs (`f0_std_st` is null at every checkpoint) — what settles late is sim and UTMOS. The 200k step count stands; the reason changes.