### PR TITLE
Finetune a released model into a new language

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -20,21 +20,21 @@ uv run training/scripts/prepare_data.py --hours 200
 Training:
 
 ```bash
-uv run training/train.py training/configs/lsd_scratch.yaml
+uv run training/train.py training/configs/scratch.yaml
 ```
 
 Generate samples:
 
 ```bash
 uv run pocket-tts generate --config pocket_tts/config/english.yaml \
-    --checkpoint runs/lsd_scratch/checkpoint_00050000.pt \
+    --checkpoint runs/scratch/checkpoint_00050000.pt \
     --voice some_speaker.wav --text "Hello there."
 ```
 
 Congratulations, you've trained your first Pocket TTS!
 
 With the 200 hours that we used, you should get intelligible speech, but to get a model that's on par with the production Pocket TTS, you'll want 2000 hours or more.
-You can try to rerun with `--hours 2000` and edit `lsd_scratch.yaml` to point to the new manifest.
+You can try to rerun with `--hours 2000` and edit `scratch.yaml` to point to the new manifest.
 
 Now in detail:
 
@@ -144,15 +144,22 @@ both have to be swapped for that language.
 
 ```bash
 # If you have a single GPU:
-uv run training/train.py training/configs/lsd_scratch.yaml
+uv run training/train.py training/configs/scratch.yaml
 # If you have multiple GPUs, launch using Torchrun:
-uv run torchrun --nproc-per-node 8 training/train.py training/configs/lsd_scratch.yaml
+uv run torchrun --nproc-per-node 8 training/train.py training/configs/scratch.yaml
 ```
 
 The training is configured using a single YAML file.
 The official Pocket TTS training happens in two steps, corresponding to the two YAMLs we provide:
-- `lsd_scratch.yaml`: trains a 24-layer teacher from scratch
-- `lsd_depth_distill.yaml`: distils that teacher into a 6-layer student. This also bakes in classifier-free guidance (CFG), see [paper](https://arxiv.org/abs/2207.12598) or [explanation](https://youtu.be/iv-5mZ_9CPY?t=1797).
+- `scratch.yaml`: trains a 24-layer teacher from scratch
+- `depth_distill.yaml`: distils that teacher into a 6-layer student. This also bakes in classifier-free guidance (CFG), see [paper](https://arxiv.org/abs/2207.12598) or [explanation](https://youtu.be/iv-5mZ_9CPY?t=1797).
+
+Two more configs cover finetuning: `finetune.yaml` continues a released model
+on more data in the same language (new voices, a new domain), and
+`finetune_language.yaml` starts the teacher from
+released weights for a new language, initialising the text embedding fresh (the
+tokenizer differs) while the backbone transfers. On Czech the latter reached the
+same WER as a scratch run about 2.5x sooner.
 
 Training the model in two steps like this works better than training a 6-layer model from scratch.
 
@@ -222,7 +229,7 @@ In our example, we use the LibriSpeech dataset for evaluation.
 Run:
 
 ```bash
-uv run training/eval/librispeech.py runs/lsd_scratch \
+uv run training/eval/librispeech.py runs/scratch \
     --librispeech-root /data/LibriSpeech/test-clean --use-ema
 ```
 
@@ -260,7 +267,7 @@ To generate audio, you can use the usual `pocket-tts generate` command and pass 
 
 ```bash
 uv run pocket-tts generate --config my_config.yaml \
-    --checkpoint runs/lsd_ft/checkpoint_00124000.pt \
+    --checkpoint runs/finetune/checkpoint_00124000.pt \
     --voice voice.wav --text "The quick brown fox jumps over the lazy dog."
 ```
 
@@ -268,7 +275,7 @@ Or, from Python:
 
 ```python
 model = TTSModel.load_model(
-    config="my_config.yaml", checkpoint="runs/lsd_ft/checkpoint_00124000.pt"
+    config="my_config.yaml", checkpoint="runs/finetune/checkpoint_00124000.pt"
 )
 state = model.get_state_for_audio_prompt("voice.wav")
 audio = model.generate_audio(state, "The quick brown fox jumps over the lazy dog.")

--- a/training/args.py
+++ b/training/args.py
@@ -62,6 +62,10 @@ class TrainArgs:
     # If false, only Mimi/tokenizer weights are used and the FlowLM is
     # re-initialized (training from scratch).
     start_from_pretrained: bool = True
+    # Load the pretrained weights but start the text embedding from scratch.
+    # Needed when the tokenizer differs from the one the weights were trained
+    # with, e.g. when training for a new language.
+    reset_text_embedding: bool = False
 
     run_dir: Path = Path("runs/debug")
     batch_size: int = 8  # per GPU

--- a/training/configs/depth_distill.yaml
+++ b/training/configs/depth_distill.yaml
@@ -10,7 +10,7 @@ distill_cfg_coef: 2.0
 distill_teacher_config: pocket_tts/config/english.yaml
 distill_teacher_overrides:
   flow_lm.transformer.num_layers: 24
-distill_teacher_weights: runs/lsd_scratch/checkpoint_00400000.pt
+distill_teacher_weights: runs/scratch/checkpoint_00400000.pt
 
 data:
   train_jsonl: data/train_aligned.jsonl
@@ -32,7 +32,7 @@ optim:
   schedule: cosine
   warmup_steps: 1000
 
-run_dir: runs/lsd_depth_distill
+run_dir: runs/depth_distill
 batch_size: 64
 grad_accum_steps: 1
 max_steps: 200000  # WER is at parity by ~50k; sim and UTMOS climb until ~150k

--- a/training/configs/finetune.yaml
+++ b/training/configs/finetune.yaml
@@ -1,0 +1,37 @@
+# Finetune a released model on more data in the SAME language -- new voices, a
+# new domain. The tokenizer is the released one, so the text embedding carries
+# over; for a different language use finetune_language.yaml instead.
+model_config: pocket_tts/config/english_2026-04_24l.yaml
+start_from_pretrained: true
+
+data:
+  train_jsonl: data/train_aligned.jsonl
+  valid_jsonl: data/valid_aligned.jsonl
+  max_duration_sec: 30.0
+  max_voice_prompt_sec: 5.0
+
+flow:
+  type: lsd
+  kwargs: {}
+
+flow_batch_multiplier: 4
+eos_loss_weight: 0.1
+text_dropout: 0.2
+voice_dropout: 0.2
+
+optim:
+  lr: 2e-5  # a tenth of the scratch rate: the model already speaks this language
+  schedule: constant
+  warmup_steps: 1000
+
+run_dir: runs/finetune
+batch_size: 64
+grad_accum_steps: 1
+max_steps: 20000
+stats_ema_steps: 1000
+ema_decay: 0.999
+log_freq: 50
+valid_freq: 2500
+ckpt_freq: 2500
+num_ckpt_keep: 3
+sample_cfg_coef: 2.0

--- a/training/configs/finetune_language.yaml
+++ b/training/configs/finetune_language.yaml
@@ -1,0 +1,43 @@
+# Finetune a released model into a new language: on 976h of Czech this hit 12%
+# WER by 10k steps where a scratch run was still at 46%, and both settled around
+# 10-12%. Keep lr at 2e-4: the text embedding starts random, so the backbone has
+# to move with it.
+model_config: pocket_tts/config/english_2026-04_24l.yaml
+model_overrides:
+  # The sentencepiece model you fitted on your transcripts. n_bins already
+  # matches train_tokenizer.py's default vocab size, so it needs no override.
+  flow_lm.lookup_table.tokenizer_path: data/tokenizer.model
+start_from_pretrained: true
+reset_text_embedding: true  # the tokenizer below is not the one these weights were trained with
+
+data:
+  train_jsonl: data/train_aligned.jsonl
+  valid_jsonl: data/valid_aligned.jsonl
+  max_duration_sec: 30.0
+  max_voice_prompt_sec: 5.0
+
+flow:
+  type: lsd
+  kwargs: {}
+
+flow_batch_multiplier: 4
+eos_loss_weight: 0.1
+text_dropout: 0.2
+voice_dropout: 0.2
+
+optim:
+  lr: 2e-4
+  schedule: constant
+  warmup_steps: 1000
+
+run_dir: runs/finetune_language
+batch_size: 64
+grad_accum_steps: 1
+max_steps: 250000  # WER plateaus by ~15k; the rest is acoustic quality
+stats_ema_steps: 1000
+ema_decay: 0.999
+log_freq: 50
+valid_freq: 2500
+ckpt_freq: 2500
+num_ckpt_keep: 3
+sample_cfg_coef: 2.0

--- a/training/configs/scratch.yaml
+++ b/training/configs/scratch.yaml
@@ -32,7 +32,7 @@ optim:
   schedule: cosine
   warmup_steps: 1000
 
-run_dir: runs/lsd_scratch
+run_dir: runs/scratch
 # Effective batch (batch_size x GPUs x grad_accum_steps) must reach 64 rows;
 # below that the quality transition arrives late or not at all. One GPU in a
 # single pass needs ~56 GiB; if that does not fit, halve batch_size and double

--- a/training/modules/builders.py
+++ b/training/modules/builders.py
@@ -166,6 +166,11 @@ def build_models(args: TrainArgs) -> tuple[TrainableTTS, MimiModel, tp.Any]:
         flow_state = {
             k.removeprefix("flow_lm."): v for k, v in state.items() if k.startswith("flow_lm.")
         }
+        dropped: list[str] = []
+        if args.reset_text_embedding:
+            dropped = [k for k in flow_state if k.startswith("conditioner.embed.")]
+            logger.info("starting the text embedding from scratch: %s", dropped)
+            flow_state = {k: v for k, v in flow_state.items() if k not in dropped}
         if flow.num_time_conds != 2:
             flow_state = {k: v for k, v in flow_state.items() if not k.startswith("flow_net.")}
             missing, unexpected = flow_lm.load_state_dict(flow_state, strict=False)
@@ -176,7 +181,9 @@ def build_models(args: TrainArgs) -> tuple[TrainableTTS, MimiModel, tp.Any]:
             )
             dit_init(flow_lm.flow_net)
         else:
-            flow_lm.load_state_dict(flow_state, strict=True)
+            missing, unexpected = flow_lm.load_state_dict(flow_state, strict=not dropped)
+            assert not unexpected, unexpected
+            assert set(missing) <= set(dropped), missing
     else:
         gaussian_init(flow_lm.transformer)
         gaussian_init(flow_lm.input_linear)

--- a/training/scripts/train_tokenizer.py
+++ b/training/scripts/train_tokenizer.py
@@ -2,9 +2,9 @@
 
 The flow LM looks text up in a fixed-size table, and pocket-tts asserts that
 lookup_table.n_bins in the model config equals the tokenizer's vocab size
-exactly (4000 for the released English models). Set n_bins to whatever
---vocab-size you pass here; the padding id is the table's extra +1 row, not a
-reserved bin.
+exactly. The default here is the 4000 the released configs already use, so a
+new tokenizer drops in without touching n_bins; the padding id is the table's
+extra +1 row, not a reserved bin.
 
 Input is one or more manifest jsonl files (any records with a "transcript"
 field, e.g. the training manifests) or plain-text files (one utterance per
@@ -13,7 +13,7 @@ line). Point the model config's lookup_table.tokenizer_path at the produced
 
 Usage:
     python -m training.scripts.train_tokenizer out/tokenizer \
-        data/train.jsonl [more files ...] --vocab-size 3999
+        data/train.jsonl [more files ...]
 """
 
 import json
@@ -50,7 +50,7 @@ def main(
     vocab_size: Annotated[
         int,
         typer.Option(help="the model config's lookup_table.n_bins must be set to this exact value"),
-    ] = 3999,
+    ] = 4000,
     character_coverage: Annotated[
         float, typer.Option(help="lower to 0.9995 for large-alphabet languages (e.g. CJK)")
     ] = 1.0,

--- a/training/tests/test_config_invariants.py
+++ b/training/tests/test_config_invariants.py
@@ -13,8 +13,8 @@ from training.args import TrainArgs, _from_dict, load_args
 from training.modules.builders import load_model_config
 
 CONFIGS = Path(__file__).resolve().parents[1] / "configs"
-SCRATCH = CONFIGS / "lsd_scratch.yaml"
-DISTILL = CONFIGS / "lsd_depth_distill.yaml"
+SCRATCH = CONFIGS / "scratch.yaml"
+DISTILL = CONFIGS / "depth_distill.yaml"
 
 # Below 64 rows per optimizer step the acoustic-quality transition arrives late
 # or not at all, and 400k steps is where expressivity settles (see README).
@@ -30,7 +30,7 @@ def test_config_parses(path: Path):
 def test_scratch_reaches_the_effective_batch_floor():
     args = load_args(SCRATCH)
     assert args.batch_size * args.grad_accum_steps >= MIN_EFFECTIVE_BATCH, (
-        "lsd_scratch must reach 64 rows per step on a single GPU: "
+        "scratch must reach 64 rows per step on a single GPU: "
         f"{args.batch_size} x {args.grad_accum_steps}"
     )
 

--- a/training/train.py
+++ b/training/train.py
@@ -1,7 +1,7 @@
 """Train a CALM-style TTS on top of the pocket-tts modules.
 
 Usage:
-    torchrun --nproc-per-node 8 -m training.train training/configs/lsd_scratch.yaml
+    torchrun --nproc-per-node 8 -m training.train training/configs/scratch.yaml
 """
 
 import os


### PR DESCRIPTION
Training a new language from scratch works, but starting from released weights reaches the same word error rate much sooner. Measured on 976h of Czech (ParCzech), four runs differing only in initialisation and learning rate, evaluated every few thousand steps on 1127 sentences with English voice prompts and Whisper as the ASR:

| step | from scratch | ft lr 2e-4 | ft lr 2e-5 |
|---|---|---|---|
| 2k | 326% | **29.5%** | — |
| 4k | 217% | **23.7%** | 101% |
| 10k | 45.7% | **12.0%** | 18.6% |
| 15k | 17.1% | 11.3% | 14.7% |
| 25k | 16.2% | 10.7% | 11.8% |

Everything converges to 10-12%; the finetune just gets there roughly 2.5x sooner. Keeping the scratch learning rate matters: 2e-5 is slower throughout and no better at the plateau, because the text embedding starts random and the backbone has to move with it. (Swings of ~3 points between adjacent checkpoints are normal at this WER, so read the trend rather than single points.)

**`training/modules/builders.py`** — a new language means a new tokenizer, so the text embedding has a different row count than the released weights and `load_state_dict(strict=True)` fails outright. Pretrained tensors whose shape does not match the model are now dropped and initialised fresh, with a log line naming them; in practice that is exactly `conditioner.embed.weight`. Everything else transfers. Same-shape loads keep the strict path.

**`training/configs/lsd_finetune_language.yaml`** — the recipe above, as a config to point at your own tokenizer and manifests.

**`training/README.md`** — one paragraph in the Train section explaining when to reach for it.