### PR TITLE
Add Apple Silicon (MPS) training support

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -96,9 +96,14 @@ uv run training/train.py training/configs/scratch_mps.yaml
 `torch.compile` targets inductor's CUDA path and is unproven on MPS. bf16 autocast and
 fused AdamW both work on the torch version the project already requires.
 
-Multi-process training stays CUDA-only, NCCL has no MPS backend. Throughput is well below
-a data-center GPU: run a few hundred steps to measure it/s on your machine before
-committing to a long run.
+Multi-process training stays CUDA-only, NCCL has no MPS backend.
+
+Measured on an M5 Pro (20-core GPU, 64 GB): 0.11 it/s sustained at `batch_size: 16`,
+`grad_accum_steps: 4` — roughly a 23 GB L4 at a third speed, so 200k steps is a
+multi-week run. Useful for development, smoke tests and finetuning experiments; plan
+on an NVIDIA GPU for a full from-scratch run. The step log's `mps drv`/`cur` figures
+flag the paging failure mode: if driver-allocated runs far above current-allocated
+and it/s decays, memory is the problem, not compute.
 
 ## Data
 

--- a/training/README.md
+++ b/training/README.md
@@ -41,7 +41,9 @@ Now in detail:
 ## Installation
 
 Requirements:
-- Linux - we don't provide official support for Windows/Mac training, but will accept bugfix PRs
+- Linux - we don't provide official support for Windows training, but will accept bugfix PRs.
+  macOS on Apple Silicon works single-device via the MPS backend, see
+  [Training on Apple Silicon](#training-on-apple-silicon)
 - One NVIDIA GPU (the default batch size wants ~56 GB; a consumer GPU runs `batch_size: 16` with
   `grad_accum_steps: 4` in ~16 GB); you can use more GPUs to train faster
 - Python 3.10+ and [uv](https://docs.astral.sh/uv/)
@@ -80,6 +82,23 @@ explicit = true
 Then `uv sync` picks up the pin like any other dependency change — no separate
 reinstall step, and it survives future `uv sync`/`uv lock` runs.
 </details>
+
+### Training on Apple Silicon
+
+Single-device training runs on the MPS backend, no CUDA required:
+
+```bash
+uv run training/train.py training/configs/scratch_mps.yaml
+```
+
+`scratch_mps.yaml` mirrors `scratch.yaml` with the consumer-GPU batching (`batch_size: 16`,
+`grad_accum_steps: 4`, same effective batch of 64) and `compile: false`: the per-layer
+`torch.compile` targets inductor's CUDA path and is unproven on MPS. bf16 autocast and
+fused AdamW both work on the torch version the project already requires.
+
+Multi-process training stays CUDA-only, NCCL has no MPS backend. Throughput is well below
+a data-center GPU: run a few hundred steps to measure it/s on your machine before
+committing to a long run.
 
 ## Data
 

--- a/training/configs/scratch_mps.yaml
+++ b/training/configs/scratch_mps.yaml
@@ -36,6 +36,9 @@ stats_ema_steps: 1000
 ema_decay: 0.999
 log_freq: 50
 valid_freq: 2500
-ckpt_freq: 2500
+# At ~0.1 it/s a step is ~9s: checkpoint every ~2.5h so a sleep or crash
+# costs little, and write audio samples often enough to track progress by ear.
+ckpt_freq: 1000
+sample_freq: 2500
 num_ckpt_keep: 3
 sample_cfg_coef: 2.0  # teachers sample guided; the baked-student default is 1.0

--- a/training/configs/scratch_mps.yaml
+++ b/training/configs/scratch_mps.yaml
@@ -1,0 +1,41 @@
+# scratch.yaml adapted for a single Apple Silicon GPU (MPS backend).
+# Same effective batch of 64 rows via the consumer-GPU recipe (16 x 4).
+# compile stays off: per-layer torch.compile targets inductor's CUDA path and
+# is unproven on the MPS backend; training runs fine eagerly, just slower.
+model_config: pocket_tts/config/english.yaml
+model_overrides:
+  flow_lm.transformer.num_layers: 24
+start_from_pretrained: false
+
+data:
+  train_jsonl: data/hifitts2_200h/train_aligned.jsonl
+  valid_jsonl: data/hifitts2_200h/valid_aligned.jsonl
+  max_duration_sec: 30.0
+  max_voice_prompt_sec: 5.0
+
+flow:
+  type: lsd
+  kwargs: {}
+
+flow_batch_multiplier: 4
+eos_loss_weight: 0.1
+text_dropout: 0.2
+voice_dropout: 0.2
+
+optim:
+  lr: 2e-4
+  schedule: cosine
+  warmup_steps: 1000
+
+run_dir: runs/scratch_mps
+batch_size: 16
+grad_accum_steps: 4
+compile: false
+max_steps: 400000
+stats_ema_steps: 1000
+ema_decay: 0.999
+log_freq: 50
+valid_freq: 2500
+ckpt_freq: 2500
+num_ckpt_keep: 3
+sample_cfg_coef: 2.0  # teachers sample guided; the baked-student default is 1.0

--- a/training/distributed.py
+++ b/training/distributed.py
@@ -16,9 +16,13 @@ def get_world_size() -> int:
     return dist.get_world_size() if dist.is_initialized() else 1
 
 
-def _require_cuda() -> None:
+def _require_accelerator() -> None:
     """Training on CPU is accidental (a mismatched torch build), not a use case."""
-    if torch.cuda.is_available() or os.environ.get("POCKET_TTS_ALLOW_CPU") == "1":
+    if (
+        torch.cuda.is_available()
+        or torch.backends.mps.is_available()
+        or os.environ.get("POCKET_TTS_ALLOW_CPU") == "1"
+    ):
         return
     if torch.version.cuda is None:
         hint = (
@@ -33,19 +37,24 @@ def _require_cuda() -> None:
             "matching build, see training/README.md."
         )
     raise SystemExit(
-        f"no CUDA device visible to torch (torch {torch.__version__}).\n{hint}\n"
+        f"no CUDA or MPS device visible to torch (torch {torch.__version__}).\n{hint}\n"
         "Set POCKET_TTS_ALLOW_CPU=1 to run on CPU anyway."
     )
 
 
 def init_distributed() -> torch.device:
-    _require_cuda()
+    _require_accelerator()
     if is_torchrun():
+        # Multi-process training stays CUDA-only: NCCL has no MPS backend.
         local_rank = int(os.environ["LOCAL_RANK"])
         torch.cuda.set_device(local_rank)
         dist.init_process_group(backend="nccl")
         return torch.device("cuda", local_rank)
-    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    if torch.backends.mps.is_available():
+        return torch.device("mps")
+    return torch.device("cpu")
 
 
 def shutdown_distributed() -> None:

--- a/training/train.py
+++ b/training/train.py
@@ -86,7 +86,7 @@ def setup(config_path: str) -> Run:
     progress = ProgressLog(run_dir / "progress.jsonl", enabled=rank == 0)
     if rank == 0:
         logger.info(f"logging to {log_path}")
-        gpu = torch.cuda.get_device_name(device) if device.type == "cuda" else "cpu"
+        gpu = torch.cuda.get_device_name(device) if device.type == "cuda" else device.type
         logger.info(f"torch {torch.__version__} | {device} ({gpu}) | world size {world_size}")
         logger.info(f"resolved config from {config_path}:\n{dump_args(args).rstrip()}")
 
@@ -118,7 +118,7 @@ def setup(config_path: str) -> Run:
         betas=args.optim.betas,
         eps=args.optim.eps,
         weight_decay=args.optim.weight_decay,
-        fused=device.type == "cuda",
+        fused=device.type in ("cuda", "mps"),
     )
     ema = EMA(model, args.ema_decay) if args.ema_decay > 0 else None
 
@@ -181,7 +181,7 @@ def main(config_path: str) -> None:
     )
 
     autocast = torch.autocast(
-        device_type=device.type, dtype=torch.bfloat16, enabled=device.type == "cuda"
+        device_type=device.type, dtype=torch.bfloat16, enabled=device.type in ("cuda", "mps")
     )
     model.train()
     if rank == 0:
@@ -290,7 +290,7 @@ def validate(
         )
     )
     autocast = torch.autocast(
-        device_type=device.type, dtype=torch.bfloat16, enabled=device.type == "cuda"
+        device_type=device.type, dtype=torch.bfloat16, enabled=device.type in ("cuda", "mps")
     )
     totals: dict[str, float] = {}
     n = 0

--- a/training/train.py
+++ b/training/train.py
@@ -221,6 +221,11 @@ def main(config_path: str) -> None:
         optimizer.step()
         if ema is not None:
             ema.update(model)
+        if device.type == "mps":
+            # Variable-length batches make the MPS caching allocator hoard a
+            # buffer set per shape, ballooning driver memory ~10x past the live
+            # tensors until macOS pages it; released each step, it stays bounded.
+            torch.mps.empty_cache()
 
         steps_since_log += 1
         if rank == 0 and step == start_step and args.compile:

--- a/training/train.py
+++ b/training/train.py
@@ -238,8 +238,15 @@ def main(config_path: str) -> None:
             last_log, steps_since_log = now, 0
             values = {k: v.item() for k, v in metrics.items() if v.numel() == 1}
             shown = {k: f"{v:.4f}" for k, v in values.items()}
+            mem = ""
+            if device.type == "mps":
+                # Driver-allocated far above current-allocated is the paging
+                # failure mode the per-step empty_cache guards against.
+                drv = torch.mps.driver_allocated_memory() / 2**30
+                cur = torch.mps.current_allocated_memory() / 2**30
+                mem = f" | mps drv {drv:.1f}G cur {cur:.1f}G"
             logger.info(
-                f"step {step + 1} | lr {lr:.2e} | grad {grad_norm:.2f} | {speed:.2f} it/s | {shown}"
+                f"step {step + 1} | lr {lr:.2e} | grad {grad_norm:.2f} | {speed:.2f} it/s | {shown}{mem}"
             )
             progress.log("train", step + 1, values, lr=lr, grad_norm=grad_norm.item(), it_s=speed)
         if rank == 0 and step - start_step == VERBOSE_STEPS - 1:


### PR DESCRIPTION
The training README says Mac training is unsupported but bugfix PRs are welcome, so here is single-device training working end-to-end on Apple Silicon via the MPS backend, plus the diagnosis and fix for a memory behaviour that otherwise makes it unusable in practice.

## What's here

- `training/distributed.py`: accept MPS as a single-process training device (torchrun/NCCL paths untouched, still CUDA-only)
- `training/train.py`: enable bf16 autocast and fused AdamW on MPS (both verified working on torch 2.13); release the MPS allocator cache after each optimizer step (see below); log `mps drv`/`cur` memory figures on step log lines when training on MPS
- `training/configs/scratch_mps.yaml`: `scratch.yaml` with the consumer-GPU batching (16 x 4, same effective batch of 64), `compile: false`, and checkpoint/sample cadence suited to multi-day consumer runs
- `training/README.md`: an Apple Silicon section with measured numbers

## The allocator fix

With variable-length batches, the MPS caching allocator keeps a cached buffer set per encountered shape and never returns freed blocks to the OS. On an M5 Pro 64 GB, driver-allocated memory grows to ~72 GB against a flat 6.7 GB of live tensors within five steps; macOS then pages the GPU working set and throughput collapses ~12x. This is the same fragmentation problem `train.py` already handles on CUDA with `expandable_segments:True`, which has no effect on MPS.

Measured on the 200h HiFiTTS-2 quickstart data, 25 steps, batch 16 x 4:

| | driver-allocated | live tensors | sustained it/s |
|---|---|---|---|
| without fix | ~72 GB (paging) | 6.7 GB | 0.008 |
| with per-step `torch.mps.empty_cache()` | 19-24 GB | 6.7 GB | 0.11, no decay |

The per-step release has no measurable cost (steps 1-3 run at the same speed with and without it). Larger micro-batches don't help on this hardware: 32 x 2 sustains 0.065 it/s and 64 x 1 exceeds physical memory on real (uncached) demand.

## Testing

- `pytest training/tests`: 65 passed on macOS (arm64, torch 2.13.0)
- 25-step instrumented benchmarks for the numbers above
- A multi-day 200h from-scratch run is currently in progress on the same machine with this exact branch; loss/grad trajectories over the first thousands of steps match the reference curves in the training README

## Limitations

- Single device only; multi-process training still requires CUDA/NCCL
- `torch.compile` is left off in the MPS config (inductor's MPS path untested here)
- At ~0.11 it/s an M5 Pro is roughly a third of an L4, so this targets development, finetuning and patient from-scratch runs rather than parity with data-centre GPUs
