### PR TITLE
Import Annotated from typing

### DIFF
--- a/pocket_tts/main.py
+++ b/pocket_tts/main.py
@@ -6,13 +6,13 @@ import tempfile
 import threading
 from pathlib import Path
 from queue import Queue
+from typing import Annotated
 
 import typer
 import uvicorn
 from fastapi import FastAPI, File, Form, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, StreamingResponse
-from typing_extensions import Annotated
 
 from pocket_tts.data.audio import stream_audio_chunks
 from pocket_tts.default_parameters import (

--- a/training/scripts/align_data.py
+++ b/training/scripts/align_data.py
@@ -27,13 +27,13 @@ import queue
 import re
 import threading
 from collections.abc import Callable
+from typing import Annotated
 
 import sphn
 import torch
 import typer
 from pydantic import BaseModel
 from tqdm import tqdm
-from typing_extensions import Annotated
 
 from pocket_tts.data.audio_utils import convert_audio
 

--- a/training/scripts/prepare_data.py
+++ b/training/scripts/prepare_data.py
@@ -30,13 +30,13 @@ import time
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from typing import Annotated
 
 import huggingface_hub
 import requests
 import typer
 from pydantic import BaseModel
 from tqdm import tqdm
-from typing_extensions import Annotated
 
 logger = logging.getLogger("prepare_data")
 

--- a/training/scripts/train_tokenizer.py
+++ b/training/scripts/train_tokenizer.py
@@ -19,11 +19,10 @@ Usage:
 import json
 import tempfile
 from pathlib import Path
-from typing import Literal
+from typing import Annotated, Literal
 
 import sentencepiece as spm
 import typer
-from typing_extensions import Annotated
 
 app = typer.Typer(pretty_exceptions_show_locals=False)
 


### PR DESCRIPTION
`Annotated` has been in `typing` since Python 3.9 and the project requires 3.10+, so the `typing_extensions` backport is not needed. Four files: `pocket_tts/main.py` and the three `training/scripts/`.

Left alone: the `typing_extensions import Self` in `flow_lm.py`, `tts_model.py` and `mlp.py` — `typing.Self` only exists from 3.11, so those are still required at our floor.

Worth knowing why CI is quiet about this: pre-commit pins ruff v0.12.7, while current ruff (0.16.4) flags it as UP035 by default. So `ruff check` locally disagrees with CI, and this class of finding will keep reappearing until the pin is bumped — happy to do that separately, it will surface more.

pre-commit passes; pytest 43/43 on 3.10.