### PR TITLE
Run the training tests in CI, and make zip lengths explicit

### DIFF
--- a/training/dataloader.py
+++ b/training/dataloader.py
@@ -238,7 +238,7 @@ class DataLoader:
                     continue
                 batch, samples = samples[: self.batch_size], samples[self.batch_size :]
                 yielded += 1
-                wavs, tokens, prompts, prompt_lens = zip(*batch)
+                wavs, tokens, prompts, prompt_lens = zip(*batch, strict=True)
                 max_len = max(len(w) for w in wavs)
                 audio = torch.zeros(len(wavs), 1, max_len)
                 frames = torch.zeros(len(wavs), dtype=torch.long)

--- a/training/eval/librispeech.py
+++ b/training/eval/librispeech.py
@@ -307,7 +307,7 @@ def score_items(items: list[dict], device, args) -> tuple[list[dict], int]:
                 eos_threshold=args.eos_threshold,
             )
         good, gens = [], []
-        for item, latents in zip(chunk, outs):
+        for item, latents in zip(chunk, outs, strict=True):
             capped = int(latents.shape[0] >= max_frames)
             if latents.shape[0] < min_frames:
                 records.append(
@@ -348,7 +348,7 @@ def score_items(items: list[dict], device, args) -> tuple[list[dict], int]:
                 e_gen = spk(gens)
                 e_ref = spk(refs_audio)
                 sims = torch.nn.functional.cosine_similarity(e_gen, e_ref, dim=-1).tolist()
-        for i, ((item, capped), hyp) in enumerate(zip(good, hyps)):
+        for i, ((item, capped), hyp) in enumerate(zip(good, hyps, strict=True)):
             rec = {
                 "ref": normalize(item["text"]),
                 "hyp": normalize(hyp),

--- a/training/modules/model.py
+++ b/training/modules/model.py
@@ -145,7 +145,7 @@ class TrainableTTS(nn.Module):
         B = len(text_tokens)
 
         rows = []
-        for tokens, voice in zip(text_tokens, voice_latents):
+        for tokens, voice in zip(text_tokens, voice_latents, strict=True):
             t_emb = fl.conditioner(TokenizedText(tokens[None].to(device)))[0]
             v_emb = F.linear(
                 voice[None].to(device, fl.speaker_proj_weight.dtype), fl.speaker_proj_weight
@@ -165,7 +165,7 @@ class TrainableTTS(nn.Module):
             pads.append(torch.zeros(B, device=device, dtype=torch.long))
 
         states = []
-        for p, pd in zip(prefixes, pads):
+        for p, pd in zip(prefixes, pads, strict=True):
             st = init_states(fl, B, p.shape[1] + max_frames + 2)
             set_state_padding(st, pd)
             states.append({"state": st, "first": True})

--- a/training/scripts/align_data.py
+++ b/training/scripts/align_data.py
@@ -106,7 +106,7 @@ def batched_word_spans(
                 j -= 1
                 frames[j] = t - 1
         spans: dict[int, tuple[int, int]] = {}
-        for f, w_idx in zip(frames, word_of_lists[b]):
+        for f, w_idx in zip(frames, word_of_lists[b], strict=True):
             if w_idx < 0:
                 continue
             s, e = spans.get(w_idx, (f, f))
@@ -329,14 +329,14 @@ def main(
                     emissions, T, [u[5] for u in chunk], [u[6] for u in chunk], blank
                 )
                 for (order, entry, wav, words, norm, _, _), spans, t_frames, n_samples in zip(
-                    chunk, spans_batch, T.tolist(), lens
+                    chunk, spans_batch, T.tolist(), lens, strict=True
                 ):
                     if spans is None:
                         skip(entry, ValueError("alignment failed"))
                         continue
                     sec_per_frame = (n_samples / sr) / t_frames
                     timed, k = [], 0
-                    for w, nw in zip(words, norm):
+                    for w, nw in zip(words, norm, strict=True):
                         if not nw or spans[k] is None:
                             timed.append({"word": w, "start": None, "end": None})
                             k += bool(nw)

--- a/training/tests/test_smoke.py
+++ b/training/tests/test_smoke.py
@@ -179,7 +179,7 @@ def test_generate_ragged_matches_batch_of_one():
     voices = [torch.randn(n, LDIM) for n in (4, 6, 5)]
 
     singles = []
-    for t, v in zip(texts, voices):
+    for t, v in zip(texts, voices, strict=True):
         torch.manual_seed(7)
         singles.append(
             model.generate(
@@ -191,7 +191,7 @@ def test_generate_ragged_matches_batch_of_one():
         texts, voices, max_frames=5, temp=0.0, n_steps=1, cfg_coef=1.0, eos_threshold=1e9
     )
     assert len(batched) == 3
-    for single, batch_row in zip(singles, batched):
+    for single, batch_row in zip(singles, batched, strict=True):
         assert single.shape == batch_row.shape
         # temp=0 removes sampling noise, so rows must agree closely; the left
         # padding must not leak into any row.
@@ -342,5 +342,5 @@ def test_grad_accum_matches_big_batch():
     net.zero_grad()
     for half in (slice(0, 4), slice(4, 8)):
         (loss_of(xs[half], ys[half]) / 2).backward()
-    for g, p in zip(big, net.parameters()):
+    for g, p in zip(big, net.parameters(), strict=True):
         assert torch.allclose(g, p.grad, atol=1e-6)


### PR DESCRIPTION
**CI only runs `./tests`.** The 64 tests under `training/tests/` — config invariants, the effective-batch floor, the dataloader, prepare_data — never execute there. They take 4.9s. Renaming every config in #254 touched several of their references and nothing in CI would have caught a miss.

```diff
-        uv run -p ${{ matrix.python-version }} pytest -v ./tests
+        uv run -p ${{ matrix.python-version }} pytest -v ./tests ./training/tests
```

**`zip(..., strict=True)` on 11 sites in `training/`.** These pair things that must be the same length: a batch and its masks (`dataloader.py`), tokens and voice latents (`model.py`), generations and their transcripts (`eval/librispeech.py`), frames and word indices (`align_data.py`). Without `strict`, a length mismatch silently drops the tail and yields a quietly wrong batch or metric instead of an error.

`load_state_dict(..., strict=False)` calls are untouched — those are deliberate (EMA shadow, the depth-distill copy, the reset-embedding path).

64 + 43 tests pass; pre-commit clean.