### PR TITLE
Run the training tests in CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,4 +32,4 @@ jobs:
       run: uv sync --dev -p ${{ matrix.python-version }}
     - name: Run pytest
       run: |
-        uv run -p ${{ matrix.python-version }} pytest -v ./tests
+        uv run -p ${{ matrix.python-version }} pytest -v ./tests ./training/tests


### PR DESCRIPTION
CI runs only `./tests`, so the 64 tests under `training/tests/` never execute there — config invariants, the effective-batch floor, the dataloader, prepare_data. They take 4.9s.

Renaming every config in #254 touched several of their references, and nothing in CI would have caught a miss.