### PR TITLE
Immutable defaults in seanet; document the two open() call sites

### DIFF
--- a/pocket_tts/data/audio.py
+++ b/pocket_tts/data/audio.py
@@ -73,7 +73,8 @@ class StreamingWAVWriter:
         """Initialize WAV writer with header."""
         # For stdout streaming, we need to handle the unseekable stream case
         # The wave module supports unseekable streams since Python 3.4
-        self.wave_writer = wave.open(self.output_stream, "wb")
+        # Closed with the underlying stream by the caller's `with f:` block.
+        self.wave_writer = wave.open(self.output_stream, "wb")  # noqa: SIM115
         self.wave_writer.setnchannels(1)  # Mono
         self.wave_writer.setsampwidth(2)  # 16-bit
         self.wave_writer.setframerate(sample_rate)
@@ -148,7 +149,7 @@ def stream_audio_chunks(
     elif is_file_like(path):
         f = path
     else:
-        f = open(path, "wb")
+        f = open(path, "wb")  # noqa: SIM115  -- closed by the `with f:` below
 
     with f:
         if path is not None:

--- a/pocket_tts/modules/seanet.py
+++ b/pocket_tts/modules/seanet.py
@@ -1,3 +1,5 @@
+from collections.abc import Sequence
+
 import numpy as np
 import torch.nn as nn
 
@@ -8,8 +10,8 @@ class SEANetResnetBlock(nn.Module):
     def __init__(
         self,
         dim: int,
-        kernel_sizes: list[int] = [3, 1],
-        dilations: list[int] = [1, 1],
+        kernel_sizes: Sequence[int] = (3, 1),
+        dilations: Sequence[int] = (1, 1),
         pad_mode: str = "reflect",
         compress: int = 2,
     ):
@@ -48,7 +50,7 @@ class SEANetEncoder(nn.Module):
         dimension: int = 128,
         n_filters: int = 32,
         n_residual_layers: int = 3,
-        ratios: list[int] = [8, 5, 4, 2],
+        ratios: Sequence[int] = (8, 5, 4, 2),
         kernel_size: int = 7,
         last_kernel_size: int = 7,
         residual_kernel_size: int = 3,
@@ -120,7 +122,7 @@ class SEANetDecoder(nn.Module):
         dimension: int = 128,
         n_filters: int = 32,
         n_residual_layers: int = 3,
-        ratios: list[int] = [8, 5, 4, 2],
+        ratios: Sequence[int] = (8, 5, 4, 2),
         kernel_size: int = 7,
         last_kernel_size: int = 7,
         residual_kernel_size: int = 3,
@@ -132,7 +134,7 @@ class SEANetDecoder(nn.Module):
         self.dimension = dimension
         self.channels = channels
         self.n_filters = n_filters
-        self.ratios = ratios
+        self.ratios = list(ratios)
         del ratios
         self.n_residual_layers = n_residual_layers
         self.hop_length = int(np.prod(self.ratios))


### PR DESCRIPTION
Two ruff findings that are worth acting on, out of ~1100 (the rest are trailing commas, missing annotations, asserts in tests, copyright headers).

**B006 — mutable defaults (`seanet.py`, 4 sites).** `kernel_sizes=[3, 1]`, `dilations=[1, 1]`, `ratios=[8, 5, 4, 2]` are shared across every instance. Nothing mutates them today, so this is latent — but it is model-construction code, and an in-place edit would silently affect every model built afterwards.

They are now `Sequence[int]` with tuple defaults. Not `tuple[int, ...]`: callers pass lists (`kernel_sizes=[residual_kernel_size, 1]`) and beartype checks annotations literally, so a tuple hint fails at runtime — `Sequence` accepts both while still ruling out a shared mutable default. `SEANetDecoder` now does `self.ratios = list(ratios)` since it stores the argument.

**SIM115 — two `open()`/`wave.open()` calls in `data/audio.py`.** Both are false positives: the handle's lifetime is the caller's `with f:` block, which the conditional-source pattern above it requires. Annotated with `# noqa` and a one-line reason rather than restructured.

111 tests pass, pre-commit clean.

Unrelated, found while testing: `SEANetEncoder()` with all defaults has always raised `AssertionError: reflect` — `pad_mode` defaults to `"reflect"` but `StreamingConv1d` accepts only `constant`/`replicate`. Pre-existing on main (verified by stashing this branch); every real caller passes `constant` from config. Not fixed here.