### PR TITLE
Stop training on a non-finite gradient

### DIFF
--- a/training/train.py
+++ b/training/train.py
@@ -218,6 +218,10 @@ def main(config_path: str) -> None:
             else:
                 scaled.backward()
         grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), args.optim.max_norm)
+        if not torch.isfinite(grad_norm):
+            # Stop before the NaN reaches the weights: the run would otherwise
+            # keep training and checkpointing garbage, and auto-resume reloads it.
+            raise SystemExit(f"non-finite gradient at step {step}")
         optimizer.step()
         if ema is not None:
             ema.update(model)


### PR DESCRIPTION
Without this, one bad step writes NaN into every weight and the run keeps going: it trains garbage, checkpoints garbage, and — with `num_ckpt_keep: 3` — deletes the last healthy checkpoints within a few thousand steps. Auto-resume then reloads the NaN weights, so even resubmission cannot recover. We hit exactly this during a long run this week: it died silently at 65k steps and burned a node for hours, and the recovery point had to be dug out of an eval directory.

The check reads the gradient norm that `clip_grad_norm_` already computes, so it costs nothing; on inf/NaN it raises `SystemExit` with the step, the run dir (whose latest checkpoint predates the failure, since the stop happens before `optimizer.step()`), and the usual causes. Under torchrun, DDP gradients are identical across ranks, so every rank stops together.

Unit test included. 107 tests pass, pre-commit clean.