### PR TITLE
Move training data loading into subprocesses

### DIFF
--- a/training/args.py
+++ b/training/args.py
@@ -19,7 +19,6 @@ class DataArgs:
     # <= 0 removes the window (any word boundary; full-prefix prompt).
     max_voice_prompt_sec: float = 5.0
     shuffle: bool = True
-    subprocess_loader: bool = True
     loader_procs: int = 3
 
 

--- a/training/args.py
+++ b/training/args.py
@@ -19,13 +19,7 @@ class DataArgs:
     # <= 0 removes the window (any word boundary; full-prefix prompt).
     max_voice_prompt_sec: float = 5.0
     shuffle: bool = True
-    # Run the training DataLoader in subprocesses feeding a bounded queue.
-    # In-process audio decode/resample steals CPU (and the GIL) from the
-    # kernel-launch thread and triples Mimi's encode wall time.
     subprocess_loader: bool = True
-    # Loader subprocesses per rank. One process is GIL-bound at ~5 batches/s;
-    # an H100 consumes ~6.5/s, so 3 leaves headroom. Scale down on many-rank
-    # runs where each rank consumes fewer batches.
     loader_procs: int = 3
 
 

--- a/training/args.py
+++ b/training/args.py
@@ -19,7 +19,7 @@ class DataArgs:
     # <= 0 removes the window (any word boundary; full-prefix prompt).
     max_voice_prompt_sec: float = 5.0
     shuffle: bool = True
-    loader_procs: int = 3
+    loader_procs: int = 2
 
 
 @dataclass

--- a/training/args.py
+++ b/training/args.py
@@ -19,7 +19,7 @@ class DataArgs:
     # <= 0 removes the window (any word boundary; full-prefix prompt).
     max_voice_prompt_sec: float = 5.0
     shuffle: bool = True
-    loader_procs: int = 2
+    loader_procs: int = 3
 
 
 @dataclass

--- a/training/args.py
+++ b/training/args.py
@@ -19,6 +19,14 @@ class DataArgs:
     # <= 0 removes the window (any word boundary; full-prefix prompt).
     max_voice_prompt_sec: float = 5.0
     shuffle: bool = True
+    # Run the training DataLoader in subprocesses feeding a bounded queue.
+    # In-process audio decode/resample steals CPU (and the GIL) from the
+    # kernel-launch thread and triples Mimi's encode wall time.
+    subprocess_loader: bool = True
+    # Loader subprocesses per rank. One process is GIL-bound at ~5 batches/s;
+    # an H100 consumes ~6.5/s, so 3 leaves headroom. Scale down on many-rank
+    # runs where each rank consumes fewer batches.
+    loader_procs: int = 3
 
 
 @dataclass

--- a/training/dataloader.py
+++ b/training/dataloader.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import numpy as np
 import sphn
 import torch
+import torch.multiprocessing as torch_mp
 
 from pocket_tts.data.audio_utils import convert_audio
 
@@ -259,6 +260,91 @@ class DataLoader:
                     f"no readable samples in {self.jsonl}: every entry failed to load "
                     f"({self._failures} failures). Check the paths in the manifest."
                 )
+
+
+def _feed_queue(q, sp_proto: bytes, loader_kwargs: dict) -> None:
+    """Entry point of the loader subprocess: rebuild the tokenizer from its
+    serialized proto (SentencePieceProcessor doesn't pickle) and push batches
+    into the bounded queue forever."""
+    import sentencepiece
+
+    sp = sentencepiece.SentencePieceProcessor()
+    sp.load_from_serialized_proto(sp_proto)
+    loader = DataLoader(tokenize=sp.encode, **loader_kwargs)
+    for batch in loader:
+        q.put(batch)
+
+
+class SubprocessDataLoader:
+    """DataLoaders running in their own processes, feeding one bounded queue.
+
+    Loading in-process competes with the training loop for CPU and the GIL,
+    which triples the wall time of Mimi's encode (it launches hundreds of
+    small kernels per batch). And the load path is GIL-bound (~12 ms/sample
+    single-thread, io_workers don't parallelize it), capping one process at
+    ~5 batches/s -- below what one fast GPU consumes -- so several processes
+    each build whole batches from a disjoint entry shard (the existing
+    rank/world_size sharding). Batches cross the process boundary via shared
+    memory. Unlike DataLoader, the interleaving of the per-shard streams is
+    nondeterministic.
+    """
+
+    def __init__(
+        self,
+        jsonl: str,
+        sp,  # sentencepiece.SentencePieceProcessor
+        batch_size: int,
+        sample_rate: int,
+        frame_rate: float,
+        max_duration_sec: float,
+        max_voice_prompt_sec: float,
+        rank: int,
+        world_size: int,
+        seed: int = 0,
+        shuffle: bool = True,
+        io_workers: int = 16,
+        num_procs: int = 3,
+        depth: int = 8,
+    ):
+        # spawn: fork is unsafe once CUDA is initialized, and the children only
+        # do CPU work anyway.
+        ctx = torch_mp.get_context("spawn")
+        self._queue = ctx.Queue(maxsize=depth)
+        self._procs = []
+        for i in range(num_procs):
+            loader_kwargs = {
+                "jsonl": jsonl,
+                "batch_size": batch_size,
+                "sample_rate": sample_rate,
+                "frame_rate": frame_rate,
+                "max_duration_sec": max_duration_sec,
+                "max_voice_prompt_sec": max_voice_prompt_sec,
+                "rank": rank * num_procs + i,
+                "world_size": world_size * num_procs,
+                "seed": seed + i,
+                "shuffle": shuffle,
+                "io_workers": io_workers,
+            }
+            proc = ctx.Process(
+                target=_feed_queue,
+                args=(self._queue, sp.serialized_model_proto(), loader_kwargs),
+                daemon=True,
+                name=f"dataloader-{i}",
+            )
+            proc.start()
+            self._procs.append(proc)
+
+    def __iter__(self) -> Iterator[Batch]:
+        while True:
+            try:
+                yield self._queue.get(timeout=60)
+            except queue.Empty:
+                dead = [p for p in self._procs if not p.is_alive()]
+                if dead:
+                    raise RuntimeError(
+                        f"dataloader subprocess(es) died (exit codes "
+                        f"{[p.exitcode for p in dead]}), check their tracebacks above"
+                    ) from None
 
 
 def _prefetch(iterator: Iterator[Batch], depth: int = 4) -> Iterator[Batch]:

--- a/training/dataloader.py
+++ b/training/dataloader.py
@@ -263,9 +263,6 @@ class DataLoader:
 
 
 def _feed_queue(q, sp_proto: bytes, loader_kwargs: dict) -> None:
-    """Entry point of the loader subprocess: rebuild the tokenizer from its
-    serialized proto (SentencePieceProcessor doesn't pickle) and push batches
-    into the bounded queue forever."""
     import sentencepiece
 
     sp = sentencepiece.SentencePieceProcessor()
@@ -276,23 +273,10 @@ def _feed_queue(q, sp_proto: bytes, loader_kwargs: dict) -> None:
 
 
 class SubprocessDataLoader:
-    """DataLoaders running in their own processes, feeding one bounded queue.
-
-    Loading in-process competes with the training loop for CPU and the GIL,
-    which triples the wall time of Mimi's encode (it launches hundreds of
-    small kernels per batch). And the load path is GIL-bound (~12 ms/sample
-    single-thread, io_workers don't parallelize it), capping one process at
-    ~5 batches/s -- below what one fast GPU consumes -- so several processes
-    each build whole batches from a disjoint entry shard (the existing
-    rank/world_size sharding). Batches cross the process boundary via shared
-    memory. Unlike DataLoader, the interleaving of the per-shard streams is
-    nondeterministic.
-    """
-
     def __init__(
         self,
         jsonl: str,
-        sp,  # sentencepiece.SentencePieceProcessor
+        sp,
         batch_size: int,
         sample_rate: int,
         frame_rate: float,
@@ -306,8 +290,6 @@ class SubprocessDataLoader:
         num_procs: int = 3,
         depth: int = 8,
     ):
-        # spawn: fork is unsafe once CUDA is initialized, and the children only
-        # do CPU work anyway.
         ctx = torch_mp.get_context("spawn")
         self._queue = ctx.Queue(maxsize=depth)
         self._procs = []

--- a/training/dataloader.py
+++ b/training/dataloader.py
@@ -262,12 +262,13 @@ class DataLoader:
                 )
 
 
-def _feed_queue(q, sp_proto: bytes, loader_kwargs: dict) -> None:
+def _feed_queue(q, sentence_piece_proto: bytes, loader_kwargs: dict) -> None:
     import sentencepiece
 
-    sp = sentencepiece.SentencePieceProcessor()
-    sp.load_from_serialized_proto(sp_proto)
-    loader = DataLoader(tokenize=sp.encode, **loader_kwargs)
+    torch_mp.set_sharing_strategy("file_system")
+    sentence_piece = sentencepiece.SentencePieceProcessor()
+    sentence_piece.load_from_serialized_proto(sentence_piece_proto)
+    loader = DataLoader(tokenize=sentence_piece.encode, **loader_kwargs)
     for batch in loader:
         q.put(batch)
 
@@ -276,7 +277,7 @@ class SubprocessDataLoader:
     def __init__(
         self,
         jsonl: str,
-        sp,
+        sentence_piece,
         batch_size: int,
         sample_rate: int,
         frame_rate: float,
@@ -303,30 +304,39 @@ class SubprocessDataLoader:
                 "max_voice_prompt_sec": max_voice_prompt_sec,
                 "rank": rank * num_procs + i,
                 "world_size": world_size * num_procs,
-                "seed": seed + i,
+                "seed": seed + rank * num_procs + i,
                 "shuffle": shuffle,
                 "io_workers": io_workers,
             }
             proc = ctx.Process(
                 target=_feed_queue,
-                args=(self._queue, sp.serialized_model_proto(), loader_kwargs),
+                args=(self._queue, sentence_piece.serialized_model_proto(), loader_kwargs),
                 daemon=True,
                 name=f"dataloader-{i}",
             )
             proc.start()
             self._procs.append(proc)
 
+    def _check_procs(self) -> None:
+        dead = [p for p in self._procs if not p.is_alive()]
+        if dead:
+            raise RuntimeError(
+                f"dataloader subprocess(es) died (exit codes "
+                f"{[p.exitcode for p in dead]}), check their tracebacks above"
+            )
+
     def __iter__(self) -> Iterator[Batch]:
+        batches = 0
         while True:
             try:
-                yield self._queue.get(timeout=60)
+                batch = self._queue.get(timeout=60)
             except queue.Empty:
-                dead = [p for p in self._procs if not p.is_alive()]
-                if dead:
-                    raise RuntimeError(
-                        f"dataloader subprocess(es) died (exit codes "
-                        f"{[p.exitcode for p in dead]}), check their tracebacks above"
-                    ) from None
+                self._check_procs()
+                continue
+            batches += 1
+            if batches % 100 == 0:
+                self._check_procs()
+            yield batch
 
 
 def _prefetch(iterator: Iterator[Batch], depth: int = 4) -> Iterator[Batch]:

--- a/training/dataloader.py
+++ b/training/dataloader.py
@@ -287,7 +287,7 @@ class SubprocessDataLoader:
         seed: int = 0,
         shuffle: bool = True,
         io_workers: int = 16,
-        num_procs: int = 2,
+        num_procs: int = 3,
         depth: int = 8,
     ):
         ctx = torch_mp.get_context("spawn")

--- a/training/dataloader.py
+++ b/training/dataloader.py
@@ -287,7 +287,7 @@ class SubprocessDataLoader:
         seed: int = 0,
         shuffle: bool = True,
         io_workers: int = 16,
-        num_procs: int = 3,
+        num_procs: int = 2,
         depth: int = 8,
     ):
         ctx = torch_mp.get_context("spawn")

--- a/training/train.py
+++ b/training/train.py
@@ -163,12 +163,12 @@ def main(config_path: str) -> None:
     optimizer, ema, device, rank = run.optimizer, run.ema, run.device, run.rank
     progress, start_step = run.progress, run.start_step
 
-    sp = model.flow_lm.conditioner.tokenizer.sp
-    tokenize = sp.encode
+    sentence_piece = model.flow_lm.conditioner.tokenizer.sp
+    tokenize = sentence_piece.encode
     train_loader = iter(
         SubprocessDataLoader(
             args.data.train_jsonl,
-            sp,
+            sentence_piece,
             args.batch_size,
             mimi.sample_rate,
             mimi.frame_rate,
@@ -176,7 +176,7 @@ def main(config_path: str) -> None:
             args.data.max_voice_prompt_sec,
             rank,
             run.world_size,
-            seed=args.seed + rank,
+            seed=args.seed,
             shuffle=args.data.shuffle,
             num_procs=args.data.loader_procs,
         )

--- a/training/train.py
+++ b/training/train.py
@@ -31,7 +31,7 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 
 from training.args import TrainArgs, dump_args, load_args, save_args
 from training.checkpointing import EMA, latest_checkpoint, load_checkpoint, save_checkpoint
-from training.dataloader import DataLoader, encode_batch
+from training.dataloader import DataLoader, SubprocessDataLoader, encode_batch
 from training.distributed import (
     avg_across_ranks,
     get_rank,
@@ -163,11 +163,13 @@ def main(config_path: str) -> None:
     optimizer, ema, device, rank = run.optimizer, run.ema, run.device, run.rank
     progress, start_step = run.progress, run.start_step
 
-    tokenize = model.flow_lm.conditioner.tokenizer.sp.encode
+    sp = model.flow_lm.conditioner.tokenizer.sp
+    tokenize = sp.encode
+    loader_cls = SubprocessDataLoader if args.data.subprocess_loader else DataLoader
     train_loader = iter(
-        DataLoader(
+        loader_cls(
             args.data.train_jsonl,
-            tokenize,
+            sp if args.data.subprocess_loader else tokenize,
             args.batch_size,
             mimi.sample_rate,
             mimi.frame_rate,
@@ -177,6 +179,7 @@ def main(config_path: str) -> None:
             run.world_size,
             seed=args.seed + rank,
             shuffle=args.data.shuffle,
+            **({"num_procs": args.data.loader_procs} if args.data.subprocess_loader else {}),
         )
     )
 

--- a/training/train.py
+++ b/training/train.py
@@ -165,11 +165,10 @@ def main(config_path: str) -> None:
 
     sp = model.flow_lm.conditioner.tokenizer.sp
     tokenize = sp.encode
-    loader_cls = SubprocessDataLoader if args.data.subprocess_loader else DataLoader
     train_loader = iter(
-        loader_cls(
+        SubprocessDataLoader(
             args.data.train_jsonl,
-            sp if args.data.subprocess_loader else tokenize,
+            sp,
             args.batch_size,
             mimi.sample_rate,
             mimi.frame_rate,
@@ -179,7 +178,7 @@ def main(config_path: str) -> None:
             run.world_size,
             seed=args.seed + rank,
             shuffle=args.data.shuffle,
-            **({"num_procs": args.data.loader_procs} if args.data.subprocess_loader else {}),
+            num_procs=args.data.loader_procs,
         )
     )
 


### PR DESCRIPTION
1xH100 PCIe, 24 CPU cores, `training/configs/lsd_scratch.yaml` defaults (batch 16 x grad_accum 4), 200h HiFiTTS-2, steps 20-40 of a 40-step run:

| | steps/s | batches/s |
|---|---|---|
| main (`a61b787`, in-process loader) | 0.79 | 3.17 |
| this branch (3 loader subprocesses) | 1.34 | 5.36 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AordVctPrGG33UnBZXQUb5
