### PR TITLE
Disable the cuDNN SDPA backend in training

### DIFF
--- a/training/train.py
+++ b/training/train.py
@@ -77,6 +77,10 @@ def setup(config_path: str) -> Run:
     """Resolve the config, build the models, restore any checkpoint."""
     setup_logging()
     torch.backends.cuda.matmul.allow_tf32 = True  # fp32 islands (Mimi encode)
+    # cuDNN's bf16 SDPA backward emits NaN at larger batch shapes (verified with
+    # detect_anomaly: ScaledDotProductCudnnAttentionBackward0; batch 128 dies
+    # within ~65k steps, flash/mem-efficient run clean and just as fast).
+    torch.backends.cuda.enable_cudnn_sdp(False)
     args = load_args(config_path)
     device = init_distributed()
     rank, world_size = get_rank(), get_world_size()


### PR DESCRIPTION
At batch 128 on H100, training dies with non-finite gradients within ~65k steps: every parameter's grad goes NaN at once while the forward losses stay healthy. `torch.autograd.set_detect_anomaly` names the op: `ScaledDotProductCudnnAttentionBackward0` — cuDNN's bf16 attention backward. The backend is shape-dispatched, which is why the shipped batch-64 recipe never hits it.

Isolation (all on the same checkpoint, data and seed): bf16+compile with cuDNN dies at ~65k; bf16 eager dies at ~65k (anomaly trace above); full fp32 runs clean; **bf16+compile with only `enable_cudnn_sdp(False)` runs 25k steps through the failure region with zero incidents**. Throughput is unchanged (3.69 vs 3.56 steps/s — flash/mem-efficient take over).

One line plus a comment; the trainer never benefits from the cuDNN backend at these shapes and it is the only one that corrupts. #262's guard turns any recurrence into a clean stop instead of a silent death.