### PR TITLE
CONTRIBUTING: encourage sharing trained models

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,17 @@ Note that two threads run in parallel in the current implementation:
 
 
 
+## Sharing your own models
+
+Contributions do not have to be code: if you train a Pocket TTS model — a new
+language, a new domain, your own data — we encourage you to share it. The
+[training README](training/README.md) covers the whole path, from preparing a
+dataset to training, and its
+[Distribution section](training/README.md#distribution) explains how to
+publish the result on Hugging Face so that anyone can use it with the official
+`pocket-tts` CLI. If you tell us about it, we are happy to link it from the
+README.
+
 ## About the overall process
 
 ### What gets accepted


### PR DESCRIPTION
A short section pointing at the training README and its Distribution instructions: training and publishing a model is a contribution too, and we link notable ones from the README.