### PR TITLE
Treat latents manifests without latents_file as stale

### DIFF
--- a/training/train_utils.py
+++ b/training/train_utils.py
@@ -166,7 +166,12 @@ def ensure_train_latents(args: TrainArgs, mimi, device, rank: int, world_size: i
     def is_fresh() -> bool:
         if not meta_path.exists():
             return False
-        return json.loads(meta_path.read_text()).get("mimi_hash") == current
+        if json.loads(meta_path.read_text()).get("mimi_hash") != current:
+            return False
+        # A manifest from an older layout (no latents_file field) would send
+        # rows down the audio path and crash the latent collate.
+        first = latents_manifest.read_text().split("\n", 1)[0]
+        return "latents_file" in json.loads(first)
 
     if not is_fresh():
         if not args.data.precompute:


### PR DESCRIPTION
A latents store produced by the pre-#270-merge sharded layout passes the Mimi-hash freshness check but its manifest rows carry latents_shard/latents_key instead of latents_file; the loader then routes rows down the audio path and _collate_latent crashes with a tuple-size error. Counting such manifests as stale makes training re-encode them automatically. Hit in practice with a store precomputed from an intermediate revision of #270.