### PR TITLE
Rename DummyQuantizer to Bottleneck

### DIFF
--- a/pocket_tts/models/mimi.py
+++ b/pocket_tts/models/mimi.py
@@ -3,8 +3,8 @@ import logging
 import torch
 from torch import nn
 
+from pocket_tts.modules.bottleneck import Bottleneck
 from pocket_tts.modules.conv import pad_for_conv1d
-from pocket_tts.modules.dummy_quantizer import DummyQuantizer
 from pocket_tts.modules.resample import ConvDownsample1d, ConvTrUpsample1d
 from pocket_tts.modules.seanet import SEANetDecoder, SEANetEncoder
 from pocket_tts.modules.transformer import ProjectedTransformer
@@ -17,7 +17,7 @@ class MimiModel(nn.Module):
         self,
         encoder: SEANetEncoder,
         decoder: SEANetDecoder,
-        quantizer: DummyQuantizer,
+        quantizer: Bottleneck,
         frame_rate: float,
         encoder_frame_rate: float,
         sample_rate: int,
@@ -125,7 +125,7 @@ class MimiModel(nn.Module):
 def build_mimi(config) -> MimiModel:
     """MimiModel from a pocket-tts config's `mimi` section."""
     from pocket_tts.modules import transformer
-    from pocket_tts.modules.dummy_quantizer import DummyQuantizer
+    from pocket_tts.modules.bottleneck import Bottleneck
     from pocket_tts.modules.seanet import SEANetDecoder, SEANetEncoder
 
     mimi_config = config.model_dump()
@@ -134,7 +134,7 @@ def build_mimi(config) -> MimiModel:
     return MimiModel(
         encoder,
         decoder,
-        DummyQuantizer(**mimi_config["quantizer"]),
+        Bottleneck(**mimi_config["quantizer"]),
         channels=mimi_config["channels"],
         sample_rate=mimi_config["sample_rate"],
         frame_rate=mimi_config["frame_rate"],

--- a/pocket_tts/modules/bottleneck.py
+++ b/pocket_tts/modules/bottleneck.py
@@ -2,10 +2,11 @@ import torch
 from torch import nn
 
 
-class DummyQuantizer(nn.Module):
-    """Simplified quantizer that only provides output projection for TTS.
+class Bottleneck(nn.Module):
+    """Output projection between the encoder space and the latent space.
 
-    This removes all unnecessary quantization logic since we don't use actual quantization.
+    Stands where Mimi's quantizer sits, but performs no quantization: the TTS
+    works on the continuous latents.
     """
 
     def __init__(self, dimension: int, output_dimension: int):


### PR DESCRIPTION
`DummyQuantizer` projects the encoder output into the latent space and quantizes nothing — `Bottleneck` says what it does. File renamed to `modules/bottleneck.py` accordingly. The `quantizer` attribute on `MimiModel` and the `quantizer` config key are unchanged, so checkpoints and configs load as before.