### PR TITLE
Implement word-level timestamps

### DIFF
--- a/docs/API Reference/python-api.md
+++ b/docs/API Reference/python-api.md
@@ -176,6 +176,48 @@ for chunk in model.generate_audio_stream(voice_state, "Long text content..."):
     # Could save chunks to file or play in real-time
 ```
 
+##### `generate_audio_with_timestamps(model_state, text_to_generate, frames_after_eos=None, copy_state=True)`
+
+Generate complete audio with word timestamps.
+
+**Parameters:** Same as `generate_audio()`
+
+**Returns:**
+- `TimestampedAudio.audio`: Audio 1D tensor with shape [samples]
+- `TimestampedAudio.words`: completed `WordTimestamp` records, in input-word order
+
+**Example:**
+```python
+result = model.generate_audio_with_timestamps(voice_state, "Hello world!")
+for word in result.words:
+    print(word.word, word.start_time, word.end_time)
+```
+
+##### `generate_audio_with_timestamps_stream(model_state, text_to_generate, frames_after_eos=None, copy_state=True)`
+
+Generate audio streaming chunks and word timestamps from text input.
+
+**Parameters:** Same as `generate_audio()`
+
+**Yields:**
+- `AudioChunk`: A chunk of generated audio with its start and end times
+- `WordStart`: The word and timestamp when it starts
+- `WordEnd`: The word and timestamps when it ends
+
+**Example:**
+```python
+from pocket_tts import AudioChunk, WordEnd, WordStart
+
+stream = model.generate_audio_with_timestamps_stream(voice_state, "Hello world!")
+for event in stream:
+    if isinstance(event, AudioChunk):
+        process_audio(event.audio)
+    elif isinstance(event, WordStart):
+        print("start", event.word_index, event.word, event.start_time)
+    elif isinstance(event, WordEnd):
+        print("end", event.word_index, event.word, event.end_time)
+```
+
 
 ## Functions
 

--- a/pocket_tts/__init__.py
+++ b/pocket_tts/__init__.py
@@ -17,6 +17,13 @@ from pocket_tts.models.model_state import export_model_state
 from pocket_tts.models.tts_model import (  # noqa: E402
     TTSModel,
 )
+from pocket_tts.timestamps import (  # noqa: E402
+    AudioChunk,
+    TimestampedAudio,
+    WordEnd,
+    WordStart,
+    WordTimestamp,
+)
 
 # Public methods:
 # TTSModel.device
@@ -24,6 +31,16 @@ from pocket_tts.models.tts_model import (  # noqa: E402
 # TTSModel.load_model
 # TTSModel.generate_audio
 # TTSModel.generate_audio_stream
+# TTSModel.generate_audio_with_timestamps
+# TTSModel.generate_audio_with_timestamps_stream
 # TTSModel.get_state_for_audio_prompt
 
-__all__ = ["TTSModel", "export_model_state"]
+__all__ = [
+    "AudioChunk",
+    "TimestampedAudio",
+    "TTSModel",
+    "WordEnd",
+    "WordStart",
+    "WordTimestamp",
+    "export_model_state",
+]

--- a/pocket_tts/config/english.yaml
+++ b/pocket_tts/config/english.yaml
@@ -2,6 +2,9 @@
 
 weights_path: hf://kyutai/pocket-tts/languages/english/model.safetensors@39592ff23c9ef80098bb74895d104c26275fe2c9
 weights_path_without_voice_cloning: hf://kyutai/pocket-tts-without-voice-cloning/languages/english/model.safetensors@d29db7978e464fb90cb3359ee0c69a273b9142cc
+timestamp_heads:
+- layer: 3
+  head: 8
 # Human evals preferred this model at 0.3 (equal WER/similarity/speech rate).
 default_temperature: 0.3
 

--- a/pocket_tts/config/english_2026-01.yaml
+++ b/pocket_tts/config/english_2026-01.yaml
@@ -2,6 +2,9 @@
 
 weights_path: hf://kyutai/pocket-tts/languages/english_2026-01/model.safetensors@39592ff23c9ef80098bb74895d104c26275fe2c9
 weights_path_without_voice_cloning: hf://kyutai/pocket-tts-without-voice-cloning/languages/english_2026-01/model.safetensors@d29db7978e464fb90cb3359ee0c69a273b9142cc
+timestamp_heads:
+- layer: 3
+  head: 8
 
 pad_with_spaces_for_short_inputs: true
 

--- a/pocket_tts/config/english_2026-04.yaml
+++ b/pocket_tts/config/english_2026-04.yaml
@@ -2,6 +2,9 @@
 
 weights_path: hf://kyutai/pocket-tts/languages/english_2026-04/model.safetensors@19f95fe2df36e79fbd9f10008595cc4c977a0fcc
 weights_path_without_voice_cloning: hf://kyutai/pocket-tts-without-voice-cloning/languages/english_2026-04/model.safetensors@d29db7978e464fb90cb3359ee0c69a273b9142cc
+timestamp_heads:
+- layer: 3
+  head: 8
 # Human evals preferred this model at 0.3 (equal WER/similarity/speech rate).
 default_temperature: 0.3
 

--- a/pocket_tts/config/english_2026-04_24l.yaml
+++ b/pocket_tts/config/english_2026-04_24l.yaml
@@ -1,5 +1,8 @@
 weights_path: hf://kyutai/pocket-tts/languages/english_2026-04_24l/model.safetensors@492522650173a0653b7575cdc25ae09810e5d741
 weights_path_without_voice_cloning: hf://kyutai/pocket-tts-without-voice-cloning/languages/english_2026-04_24l/model.safetensors@e81d79e8194ad4c7ce879c87a4258ef20cbf2487
+timestamp_heads:
+- layer: 14
+  head: 10
 
 default_temperature: 0.3
 flow_lm:

--- a/pocket_tts/config/french_24l.yaml
+++ b/pocket_tts/config/french_24l.yaml
@@ -2,6 +2,11 @@
 
 weights_path: hf://kyutai/pocket-tts/languages/french_24l/model.safetensors@39592ff23c9ef80098bb74895d104c26275fe2c9
 weights_path_without_voice_cloning: hf://kyutai/pocket-tts-without-voice-cloning/languages/french_24l/model.safetensors@d29db7978e464fb90cb3359ee0c69a273b9142cc
+timestamp_heads:
+- layer: 11
+  head: 9
+- layer: 17
+  head: 8
 
 remove_semicolons: true
 model_recommended_frames_after_eos: 8

--- a/pocket_tts/config/german.yaml
+++ b/pocket_tts/config/german.yaml
@@ -2,6 +2,9 @@
 
 weights_path: hf://kyutai/pocket-tts/languages/german/model.safetensors@39592ff23c9ef80098bb74895d104c26275fe2c9
 weights_path_without_voice_cloning: hf://kyutai/pocket-tts-without-voice-cloning/languages/german/model.safetensors@d29db7978e464fb90cb3359ee0c69a273b9142cc
+timestamp_heads:
+- layer: 3
+  head: 6
 
 remove_semicolons: true
 

--- a/pocket_tts/config/german_24l.yaml
+++ b/pocket_tts/config/german_24l.yaml
@@ -2,6 +2,11 @@
 
 weights_path: hf://kyutai/pocket-tts/languages/german_24l/model.safetensors@39592ff23c9ef80098bb74895d104c26275fe2c9
 weights_path_without_voice_cloning: hf://kyutai/pocket-tts-without-voice-cloning/languages/german_24l/model.safetensors@d29db7978e464fb90cb3359ee0c69a273b9142cc
+timestamp_heads:
+- layer: 3
+  head: 6
+- layer: 16
+  head: 6
 
 remove_semicolons: true
 

--- a/pocket_tts/config/italian.yaml
+++ b/pocket_tts/config/italian.yaml
@@ -2,6 +2,9 @@
 
 weights_path: hf://kyutai/pocket-tts/languages/italian/model.safetensors@39592ff23c9ef80098bb74895d104c26275fe2c9
 weights_path_without_voice_cloning: hf://kyutai/pocket-tts-without-voice-cloning/languages/italian/model.safetensors@d29db7978e464fb90cb3359ee0c69a273b9142cc
+timestamp_heads:
+- layer: 4
+  head: 0
 
 
 flow_lm:

--- a/pocket_tts/config/italian_24l.yaml
+++ b/pocket_tts/config/italian_24l.yaml
@@ -2,6 +2,11 @@
 
 weights_path: hf://kyutai/pocket-tts/languages/italian_24l/model.safetensors@39592ff23c9ef80098bb74895d104c26275fe2c9
 weights_path_without_voice_cloning: hf://kyutai/pocket-tts-without-voice-cloning/languages/italian_24l/model.safetensors@d29db7978e464fb90cb3359ee0c69a273b9142cc
+timestamp_heads:
+- layer: 4
+  head: 0
+- layer: 15
+  head: 12
 
 
 flow_lm:

--- a/pocket_tts/config/portuguese.yaml
+++ b/pocket_tts/config/portuguese.yaml
@@ -2,6 +2,9 @@
 
 weights_path: hf://kyutai/pocket-tts/languages/portuguese/model.safetensors@39592ff23c9ef80098bb74895d104c26275fe2c9
 weights_path_without_voice_cloning: hf://kyutai/pocket-tts-without-voice-cloning/languages/portuguese/model.safetensors@d29db7978e464fb90cb3359ee0c69a273b9142cc
+timestamp_heads:
+- layer: 3
+  head: 14
 
 
 flow_lm:

--- a/pocket_tts/config/portuguese_24l.yaml
+++ b/pocket_tts/config/portuguese_24l.yaml
@@ -2,6 +2,11 @@
 
 weights_path: hf://kyutai/pocket-tts/languages/portuguese_24l/model.safetensors@39592ff23c9ef80098bb74895d104c26275fe2c9
 weights_path_without_voice_cloning: hf://kyutai/pocket-tts-without-voice-cloning/languages/portuguese_24l/model.safetensors@d29db7978e464fb90cb3359ee0c69a273b9142cc
+timestamp_heads:
+- layer: 3
+  head: 14
+- layer: 15
+  head: 9
 
 
 flow_lm:

--- a/pocket_tts/config/spanish.yaml
+++ b/pocket_tts/config/spanish.yaml
@@ -2,6 +2,9 @@
 
 weights_path: hf://kyutai/pocket-tts/languages/spanish/model.safetensors@39592ff23c9ef80098bb74895d104c26275fe2c9
 weights_path_without_voice_cloning: hf://kyutai/pocket-tts-without-voice-cloning/languages/spanish/model.safetensors@d29db7978e464fb90cb3359ee0c69a273b9142cc
+timestamp_heads:
+- layer: 2
+  head: 3
 
 
 flow_lm:

--- a/pocket_tts/config/spanish_24l.yaml
+++ b/pocket_tts/config/spanish_24l.yaml
@@ -2,6 +2,9 @@
 
 weights_path: hf://kyutai/pocket-tts/languages/spanish_24l/model.safetensors@39592ff23c9ef80098bb74895d104c26275fe2c9
 weights_path_without_voice_cloning: hf://kyutai/pocket-tts-without-voice-cloning/languages/spanish_24l/model.safetensors@d29db7978e464fb90cb3359ee0c69a273b9142cc
+timestamp_heads:
+- layer: 6
+  head: 9
 
 
 flow_lm:

--- a/pocket_tts/models/flow_lm.py
+++ b/pocket_tts/models/flow_lm.py
@@ -9,6 +9,7 @@ from typing_extensions import Self
 from pocket_tts.modules.mlp import SimpleMLPAdaLN
 from pocket_tts.modules.text_conditioner import LUTConditioner
 from pocket_tts.modules.transformer import StreamingTransformer
+from pocket_tts.timestamps.alignment import SelectedAttentionCapture
 from pocket_tts.utils.config import FlowLMConfig
 
 logger = logging.getLogger(__name__)
@@ -117,6 +118,7 @@ class FlowLMModel(nn.Module):
         temp: float,
         noise_clamp: float | None,
         eos_threshold: float,
+        attention_capture: SelectedAttentionCapture | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Apply language model on sequence and conditions.
         Given a tensor of sequence of shape [B, S, ldim], returns the loss in training mode
@@ -136,7 +138,13 @@ class FlowLMModel(nn.Module):
         sequence = torch.where(torch.isnan(sequence), self.bos_emb, sequence)
         input_ = self.input_linear(sequence)
 
-        transformer_out = self.backbone(input_, text_embeddings, sequence, model_state=model_state)
+        transformer_out = self.backbone(
+            input_,
+            text_embeddings,
+            sequence,
+            model_state=model_state,
+            attention_capture=attention_capture,
+        )
         transformer_out = transformer_out.to(torch.float32)
         assert sampler_decode_steps > 0
 
@@ -155,7 +163,12 @@ class FlowLMModel(nn.Module):
         return decode(conditioned_flow, noise, sampler_decode_steps), out_eos
 
     def backbone(
-        self, input_, text_embeddings: torch.Tensor, sequence, model_state: dict
+        self,
+        input_,
+        text_embeddings: torch.Tensor,
+        sequence,
+        model_state: dict,
+        attention_capture: SelectedAttentionCapture | None = None,
     ) -> torch.Tensor:
         # Most of the time, one of those two tensors is empty, it allows us
         # to input text or audio embeddings into the model without adding an
@@ -165,7 +178,7 @@ class FlowLMModel(nn.Module):
         #     torch.save(text_embeddings, "debug_flow_lm_text_embeddings.pt")
         input_ = torch.cat([text_embeddings, input_], dim=1)
         # transformer_out = self.transformer(input_, model_state=model_state)
-        transformer_out = self.transformer(input_, model_state)
+        transformer_out = self.transformer(input_, model_state, attention_capture=attention_capture)
         if self.out_norm:
             transformer_out = self.out_norm(transformer_out)
         # remove the prefix from the model outputs (condition is prepended)
@@ -181,6 +194,7 @@ class FlowLMModel(nn.Module):
         temp: float,
         noise_clamp: float | None,
         eos_threshold: float,
+        attention_capture: SelectedAttentionCapture | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Sample next latent from the model given a sequence and a set of conditions.
         Args:
@@ -201,6 +215,7 @@ class FlowLMModel(nn.Module):
             noise_clamp=noise_clamp,
             eos_threshold=eos_threshold,
             model_state=model_state,
+            attention_capture=attention_capture,
         )
 
         return result

--- a/pocket_tts/models/tts_model.py
+++ b/pocket_tts/models/tts_model.py
@@ -32,6 +32,9 @@ from pocket_tts.models.model_state import _import_model_state, _is_safetensors_s
 from pocket_tts.models.text_chunking import prepare_text_prompt, split_into_best_sentences
 from pocket_tts.modules.stateful_module import StatefulModule, increment_steps, init_states
 from pocket_tts.quantization import RECOMMENDED_CONFIG, apply_dynamic_int8
+from pocket_tts.timestamps.alignment import SelectedAttentionCapture, WordAlignment, is_voiced
+from pocket_tts.timestamps.records import AudioChunk, TimestampedAudio, WordEnd, WordTimestamp
+from pocket_tts.timestamps.text import _iter_timestamp_text_chunks
 from pocket_tts.utils.config import CONFIGS_DIR, Config, load_config
 from pocket_tts.utils.utils import (
     _ORIGINS_OF_PREDEFINED_VOICES,
@@ -367,6 +370,7 @@ class TTSModel(nn.Module):
         text_tokens: torch.Tensor | None = None,
         backbone_input_latents: torch.Tensor | None = None,
         audio_conditioning: torch.Tensor | None = None,
+        attention_capture: SelectedAttentionCapture | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """First one is the backbone output, second one is the audio decoding output."""
         if text_tokens is None:
@@ -385,6 +389,7 @@ class TTSModel(nn.Module):
             backbone_input_latents=backbone_input_latents,
             model_state=model_state,
             audio_conditioning=audio_conditioning,
+            attention_capture=attention_capture,
         )
         increment_by = (
             text_tokens.shape[1] + backbone_input_latents.shape[1] + audio_conditioning.shape[1]
@@ -398,6 +403,7 @@ class TTSModel(nn.Module):
         text_tokens: torch.Tensor,
         backbone_input_latents: torch.Tensor,
         audio_conditioning: torch.Tensor,
+        attention_capture: SelectedAttentionCapture | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         text_embeddings = self.flow_lm.conditioner(text_tokens)
         text_embeddings = torch.cat([text_embeddings, audio_conditioning], dim=1)
@@ -410,6 +416,7 @@ class TTSModel(nn.Module):
             temp=self.temp,
             noise_clamp=self.noise_clamp,
             eos_threshold=self.eos_threshold,
+            attention_capture=attention_capture,
         )
         return output_embeddings[:, None, :], is_eos
 
@@ -513,6 +520,55 @@ class TTSModel(nn.Module):
         except Exception as e:
             # Put error in result queue
             result_queue.put(("error", e))
+
+    @torch.no_grad
+    def _decode_timestamped_audio_worker(
+        self,
+        latents_queue: queue.Queue,
+        result_queue: queue.Queue,
+        mimi_sequence_length: int,
+        mimi_steps_per_latent: int,
+        alignment: WordAlignment,
+        time_offset: float,
+        cancel_event: threading.Event,
+    ):
+        try:
+            mimi_state = init_states(self.mimi, batch_size=1, sequence_length=mimi_sequence_length)
+            generated_samples = 0
+            while True:
+                item = latents_queue.get()
+                if item is None or cancel_event.is_set():
+                    break
+                latent, unit_scores = item
+                mimi_decoding_input = latent * self.flow_lm.emb_std + self.flow_lm.emb_mean
+                audio_frame = self.mimi.decode_from_latent(mimi_decoding_input, mimi_state)
+                increment_steps(self.mimi, mimi_state, increment=mimi_steps_per_latent)
+
+                frame_audio = audio_frame[0, 0]
+                frame_start = time_offset + generated_samples / self.sample_rate
+                generated_samples += frame_audio.shape[-1]
+                frame_end = time_offset + generated_samples / self.sample_rate
+                voiced = is_voiced(frame_audio)
+                events = alignment.process_frame(unit_scores, voiced, frame_start)
+                for event in events:
+                    result_queue.put(("event", event))
+                result_queue.put(
+                    (
+                        "event",
+                        AudioChunk(audio=frame_audio, start_time=frame_start, end_time=frame_end),
+                    )
+                )
+                latents_queue.task_done()
+
+            if cancel_event.is_set():
+                return
+
+            audio_end = time_offset + generated_samples / self.sample_rate
+            for event in alignment.finish(audio_end):
+                result_queue.put(("event", event))
+            result_queue.put(("done", audio_end))
+        except Exception as error:
+            result_queue.put(("error", error))
 
     @torch.no_grad
     def generate_audio(
@@ -671,6 +727,184 @@ class TTSModel(nn.Module):
                 copy_state=copy_state,
             )
 
+    def generate_audio_with_timestamps(
+        self,
+        model_state: dict,
+        text_to_generate: str,
+        max_tokens: int = MAX_TOKEN_PER_CHUNK,
+        frames_after_eos: int | None = None,
+        copy_state: bool = True,
+    ) -> TimestampedAudio:
+        """Generate audio and completed word-level timestamps."""
+
+        stream = self.generate_audio_with_timestamps_stream(
+            model_state=model_state,
+            text_to_generate=text_to_generate,
+            max_tokens=max_tokens,
+            frames_after_eos=frames_after_eos,
+            copy_state=copy_state,
+        )
+        audio_chunks = []
+        words = []
+        for event in stream:
+            if isinstance(event, AudioChunk):
+                audio_chunks.append(event.audio)
+            elif isinstance(event, WordEnd):
+                words.append(
+                    WordTimestamp(event.word, event.word_index, event.start_time, event.end_time)
+                )
+        audio = (
+            torch.cat(audio_chunks, dim=0)
+            if audio_chunks
+            else torch.empty(0, dtype=torch.float32, device=self.device)
+        )
+        return TimestampedAudio(audio=audio, words=tuple(words))
+
+    def generate_audio_with_timestamps_stream(
+        self,
+        model_state: dict,
+        text_to_generate: str,
+        max_tokens: int = MAX_TOKEN_PER_CHUNK,
+        frames_after_eos: int | None = None,
+        copy_state: bool = True,
+    ):
+        """Stream tagged audio chunks and word start/end events."""
+
+        if self.config.timestamp_heads is None:
+            raise ValueError(
+                "Word timestamps are not supported by this model config because "
+                "timestamp_heads is absent. Use generate_audio() or "
+                "generate_audio_stream() for ordinary generation."
+            )
+        return self._generate_audio_with_timestamps_events(
+            model_state=model_state,
+            text_to_generate=text_to_generate,
+            max_tokens=max_tokens,
+            frames_after_eos=frames_after_eos,
+            copy_state=copy_state,
+        )
+
+    @torch.no_grad
+    def _generate_audio_with_timestamps_events(
+        self,
+        model_state: dict,
+        text_to_generate: str,
+        max_tokens: int,
+        frames_after_eos: int | None,
+        copy_state: bool,
+    ):
+        if frames_after_eos is None:
+            frames_after_eos = self.model_recommended_frames_after_eos
+        chunks = split_into_best_sentences(
+            self.flow_lm.conditioner.tokenizer,
+            text_to_generate,
+            max_tokens,
+            self.pad_with_spaces_for_short_inputs,
+            remove_semicolons=self.remove_semicolons,
+        )
+        timestamp_chunks = _iter_timestamp_text_chunks(
+            text_to_generate, chunks, self.flow_lm.conditioner.tokenizer.sp, best_effort=True
+        )
+        time_offset = 0.0
+        for timestamp_chunk in timestamp_chunks:
+            _, frames_after_eos_guess = prepare_text_prompt(
+                timestamp_chunk.text, self.pad_with_spaces_for_short_inputs, self.remove_semicolons
+            )
+            effective_frames = (
+                frames_after_eos if frames_after_eos is not None else frames_after_eos_guess + 2
+            )
+            time_offset = yield from self._generate_audio_with_timestamps_short_text(
+                model_state=model_state,
+                timestamp_chunk=timestamp_chunk,
+                frames_after_eos=effective_frames,
+                copy_state=copy_state,
+                time_offset=time_offset,
+            )
+
+    @torch.no_grad
+    def _generate_audio_with_timestamps_short_text(
+        self,
+        model_state: dict,
+        timestamp_chunk,
+        frames_after_eos: int,
+        copy_state: bool,
+        time_offset: float,
+    ):
+        if copy_state:
+            model_state = copy.deepcopy(model_state)
+
+        prepared = self._prepare_timestamp_text_chunk(timestamp_chunk)
+        token_count = prepared.shape[1]
+        if timestamp_chunk.token_to_unit.shape[0] != token_count:
+            raise RuntimeError("Timestamp token mapping does not match FlowLM tokenization")
+        max_gen_len = self._estimate_max_gen_len(token_count)
+        mimi_steps_per_latent = int(self.mimi.encoder_frame_rate / self.mimi.frame_rate)
+        mimi_sequence_length = max_gen_len * mimi_steps_per_latent
+        text_start = self._flow_lm_current_end(model_state)
+        selected_heads = tuple(
+            (selected.layer, selected.head) for selected in self.config.timestamp_heads or ()
+        )
+        capture = SelectedAttentionCapture(
+            heads=selected_heads,
+            text_start=text_start,
+            text_end=text_start + token_count,
+            token_to_unit=timestamp_chunk.token_to_unit,
+        )
+        alignment = WordAlignment(timestamp_chunk.units)
+
+        latents_queue = queue.Queue()
+        result_queue = queue.Queue()
+        cancel_event = threading.Event()
+        decoder_thread = threading.Thread(
+            target=self._decode_timestamped_audio_worker,
+            args=(
+                latents_queue,
+                result_queue,
+                mimi_sequence_length,
+                mimi_steps_per_latent,
+                alignment,
+                time_offset,
+                cancel_event,
+            ),
+            daemon=True,
+        )
+        decoder_thread.start()
+        generation_thread: threading.Thread | None = None
+        audio_end = time_offset
+        try:
+            generation_thread = self._generate(
+                model_state=model_state,
+                prepared=prepared,
+                max_gen_len=max_gen_len,
+                frames_after_eos=frames_after_eos,
+                latents_queue=latents_queue,
+                result_queue=result_queue,
+                attention_capture=capture,
+                cancel_event=cancel_event,
+            )
+
+            while True:
+                kind, value = result_queue.get()
+                if kind == "event":
+                    yield value
+                elif kind == "done":
+                    audio_end = value
+                    break
+                elif kind == "error":
+                    raise value
+        finally:
+            cancel_event.set()
+            latents_queue.put(None)
+            if generation_thread is not None:
+                generation_thread.join()
+            decoder_thread.join()
+        return audio_end
+
+    def _prepare_timestamp_text_chunk(self, timestamp_chunk) -> torch.Tensor:
+        if timestamp_chunk.prepared_tokens is None:
+            return self.flow_lm.conditioner.prepare(timestamp_chunk.text)
+        return timestamp_chunk.prepared_tokens.to(self.flow_lm.device)
+
     @torch.no_grad
     def _generate_audio_stream_short_text(
         self, model_state: dict, text_to_generate: str, frames_after_eos: int, copy_state: bool
@@ -754,7 +988,9 @@ class TTSModel(nn.Module):
         frames_after_eos: int,
         latents_queue: queue.Queue,
         result_queue: queue.Queue,
-    ):
+        attention_capture: SelectedAttentionCapture | None = None,
+        cancel_event: threading.Event | None = None,
+    ) -> threading.Thread:
         token_count = prepared.shape[1]
         current_end = self._flow_lm_current_end(model_state)
         required_len = current_end + token_count + max_gen_len
@@ -766,7 +1002,12 @@ class TTSModel(nn.Module):
         def run_generation():
             try:
                 self._autoregressive_generation(
-                    model_state, max_gen_len, frames_after_eos, latents_queue
+                    model_state,
+                    max_gen_len,
+                    frames_after_eos,
+                    latents_queue,
+                    attention_capture=attention_capture,
+                    cancel_event=cancel_event,
                 )
             except Exception as e:
                 logger.error(f"Error in autoregressive generation: {e}")
@@ -780,10 +1021,17 @@ class TTSModel(nn.Module):
 
         generation_thread = threading.Thread(target=run_generation, daemon=True)
         generation_thread.start()
+        return generation_thread
 
     @torch.no_grad
     def _autoregressive_generation(
-        self, model_state: dict, max_gen_len: int, frames_after_eos: int, latents_queue: queue.Queue
+        self,
+        model_state: dict,
+        max_gen_len: int,
+        frames_after_eos: int,
+        latents_queue: queue.Queue,
+        attention_capture: SelectedAttentionCapture | None = None,
+        cancel_event: threading.Event | None = None,
     ):
         backbone_input = torch.full(
             (1, 1, self.flow_lm.ldim),
@@ -793,30 +1041,46 @@ class TTSModel(nn.Module):
         )
         steps_times = []
         eos_step = None
-        for generation_step in range(max_gen_len):
-            with display_execution_time("Generating latent", print_output=False) as timer:
-                next_latent, is_eos = self._run_flow_lm_and_increment_step(
-                    model_state=model_state, backbone_input_latents=backbone_input
-                )
-                if is_eos.item() and eos_step is None:
-                    eos_step = generation_step
-                if eos_step is not None and generation_step >= eos_step + frames_after_eos:
+        try:
+            for generation_step in range(max_gen_len):
+                if cancel_event is not None and cancel_event.is_set():
                     break
+                with display_execution_time("Generating latent", print_output=False) as timer:
+                    if attention_capture is not None:
+                        attention_capture.begin_frame()
+                    next_latent, is_eos = self._run_flow_lm_and_increment_step(
+                        model_state=model_state,
+                        backbone_input_latents=backbone_input,
+                        attention_capture=attention_capture,
+                    )
+                    if cancel_event is not None and cancel_event.is_set():
+                        break
+                    unit_scores = (
+                        attention_capture.finish_frame() if attention_capture is not None else None
+                    )
+                    if is_eos.item() and eos_step is None:
+                        eos_step = generation_step
+                    if eos_step is not None and generation_step >= eos_step + frames_after_eos:
+                        break
 
-                # Add generated latent to queue for immediate decoding
-                latents_queue.put(next_latent)
-                backbone_input = next_latent
-            steps_times.append(timer.elapsed_time_ms)
-        else:
-            if os.environ.get("KPOCKET_TTS_ERROR_WITHOUT_EOS", "0") == "1":
-                raise RuntimeError("Generation reached maximum length without EOS!")
-            logger.warning(
-                "Maximum generation length reached without EOS, this very often indicates an error."
-            )
-
-        # Add sentinel value to signal end of generation
-        latents_queue.put(None)
-        logger.info("Average generation step time: %d ms", int(statistics.mean(steps_times)))
+                    # Add generated latent to queue for immediate decoding.
+                    if unit_scores is None:
+                        latents_queue.put(next_latent)
+                    else:
+                        latents_queue.put((next_latent, unit_scores))
+                    backbone_input = next_latent
+                steps_times.append(timer.elapsed_time_ms)
+            else:
+                if os.environ.get("KPOCKET_TTS_ERROR_WITHOUT_EOS", "0") == "1":
+                    raise RuntimeError("Generation reached maximum length without EOS!")
+                logger.warning(
+                    "Maximum generation length reached without EOS, this very often indicates an error."
+                )
+        finally:
+            # Wake the decoder on normal completion, cancellation, and generation errors.
+            latents_queue.put(None)
+        if steps_times:
+            logger.info("Average generation step time: %d ms", int(statistics.mean(steps_times)))
 
     @lru_cache(maxsize=2)
     def _cached_get_state_for_audio_prompt(

--- a/pocket_tts/modules/attention.py
+++ b/pocket_tts/modules/attention.py
@@ -4,6 +4,7 @@ from torch.nn import functional as F
 
 from pocket_tts.modules.rope import RotaryEmbedding
 from pocket_tts.modules.stateful_module import StatefulModule
+from pocket_tts.timestamps.alignment import SelectedAttentionCapture
 
 
 def complete_kv(
@@ -168,7 +169,12 @@ class StreamingMultiheadAttention(StatefulModule):
         self._cache_backend.increment_step(state, increment)
 
     def forward(
-        self, query: torch.Tensor, model_state: dict | None, attn_mask: torch.Tensor | None = None
+        self,
+        query: torch.Tensor,
+        model_state: dict | None,
+        attn_mask: torch.Tensor | None = None,
+        attention_capture: SelectedAttentionCapture | None = None,
+        layer_index: int | None = None,
     ):
         state = None if model_state is None else self.get_state(model_state)
 
@@ -192,11 +198,15 @@ class StreamingMultiheadAttention(StatefulModule):
                 1, -1
             )
             attn_mask = _build_attention_mask(pos_q, pos_k, self.context)
+
         x = F.scaled_dot_product_attention(q, k_attn, v_attn, attn_mask, dropout_p=0.0)
         x = x.transpose(1, 2)
         # Reshape from (b, t, h, d) to (b, t, h*d)
         b, t, h, d = x.shape
         x = x.reshape(b, t, h * d)
         x = self.out_proj(x)
+
+        if attention_capture is not None and layer_index is not None:
+            attention_capture.capture_attention(layer_index, q, k_attn)
 
         return x

--- a/pocket_tts/modules/transformer.py
+++ b/pocket_tts/modules/transformer.py
@@ -6,6 +6,7 @@ from typing_extensions import Self
 from pocket_tts.modules.attention import StreamingMultiheadAttention, _cached_causal_mask
 from pocket_tts.modules.layer_scale import LayerScale
 from pocket_tts.modules.rope import RotaryEmbedding
+from pocket_tts.timestamps.alignment import SelectedAttentionCapture
 from pocket_tts.utils.config import FlowLMTransformerConfig
 
 
@@ -43,17 +44,39 @@ class StreamingTransformerLayer(nn.Module):
         return x_orig.to(update) + self.layer_scale_2(update)
 
     def _sa_block(
-        self, x: torch.Tensor, model_state: dict | None, attn_mask: torch.Tensor | None = None
+        self,
+        x: torch.Tensor,
+        model_state: dict | None,
+        attn_mask: torch.Tensor | None = None,
+        attention_capture: SelectedAttentionCapture | None = None,
+        layer_index: int | None = None,
     ) -> torch.Tensor:
         x_orig = x
         x = self.norm1(x)
-        update = self.self_attn(x, model_state, attn_mask=attn_mask)
+        update = self.self_attn(
+            x,
+            model_state,
+            attn_mask=attn_mask,
+            attention_capture=attention_capture,
+            layer_index=layer_index,
+        )
         return x_orig.to(update) + self.layer_scale_1(update)
 
     def forward(
-        self, x: torch.Tensor, model_state: dict | None, attn_mask: torch.Tensor | None = None
+        self,
+        x: torch.Tensor,
+        model_state: dict | None,
+        attn_mask: torch.Tensor | None = None,
+        attention_capture: SelectedAttentionCapture | None = None,
+        layer_index: int | None = None,
     ) -> torch.Tensor:
-        x = self._sa_block(x, model_state, attn_mask)
+        x = self._sa_block(
+            x,
+            model_state,
+            attn_mask=attn_mask,
+            attention_capture=attention_capture,
+            layer_index=layer_index,
+        )
         x = self._ff_block(x)
         return x
 
@@ -99,14 +122,25 @@ class StreamingTransformer(nn.Module):
             max_period=float(config.max_period),
         )
 
-    def forward(self, x: torch.Tensor, model_state: dict | None):
+    def forward(
+        self,
+        x: torch.Tensor,
+        model_state: dict | None,
+        attention_capture: SelectedAttentionCapture | None = None,
+    ):
         attn_mask = None
         if model_state is None:
             # Stateless (training) path: one shared mask for all layers, built
             # outside any compiled region.
             attn_mask = _cached_causal_mask(x.shape[1], self.layers[0].self_attn.context, x.device)
-        for layer in self.layers:
-            x = layer(x, model_state, attn_mask=attn_mask)
+        for layer_index, layer in enumerate(self.layers):
+            x = layer(
+                x,
+                model_state,
+                attn_mask=attn_mask,
+                attention_capture=attention_capture,
+                layer_index=layer_index,
+            )
         return x
 
 

--- a/pocket_tts/timestamps/__init__.py
+++ b/pocket_tts/timestamps/__init__.py
@@ -1,0 +1,15 @@
+"""Public timestamp records and compatibility exports for timestamp internals."""
+
+from .alignment import SelectedAttentionCapture as SelectedAttentionCapture
+from .alignment import WordAlignment as WordAlignment
+from .alignment import is_voiced as is_voiced
+from .records import AudioChunk as AudioChunk
+from .records import TimestampedAudio as TimestampedAudio
+from .records import TimestampEvent as TimestampEvent
+from .records import WordEnd as WordEnd
+from .records import WordStart as WordStart
+from .records import WordTimestamp as WordTimestamp
+from .text import TimestampTextChunk as TimestampTextChunk
+from .text import _SourceWord as _SourceWord
+from .text import _TextUnit as _TextUnit
+from .text import build_timestamp_text_chunks as build_timestamp_text_chunks

--- a/pocket_tts/timestamps/alignment.py
+++ b/pocket_tts/timestamps/alignment.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import torch
+from beartype.typing import Iterable
+
+from .records import WordEnd, WordStart
+from .text import _SourceWord, _TextUnit
+
+_SILENCE_RMS_THRESHOLD = torch.tensor(1e-3, dtype=torch.float32).item()
+_NON_NEXT_ATTENTION_THRESHOLD = 0.001
+
+
+def is_voiced(audio: torch.Tensor) -> bool:
+    samples = audio.detach().to(dtype=torch.float32).reshape(-1)
+    if not samples.numel():
+        return False
+    energy = torch.dot(samples, samples).item()
+    threshold_energy = _SILENCE_RMS_THRESHOLD**2 * samples.numel()
+    return energy > threshold_energy
+
+
+class SelectedAttentionCapture:
+    """Collect configured FlowLM heads and reduce them to text-unit scores."""
+
+    def __init__(
+        self,
+        heads: Iterable[tuple[int, int]],
+        text_start: int,
+        text_end: int,
+        token_to_unit: torch.Tensor,
+    ):
+        self.heads = tuple(heads)
+        self.text_start = text_start
+        self.text_end = text_end
+        self.token_to_unit = token_to_unit
+        heads_by_layer: dict[int, list[int]] = {}
+        for layer, head in self.heads:
+            heads_by_layer.setdefault(layer, []).append(head)
+        self._heads_by_layer = {
+            layer: tuple(layer_heads) for layer, layer_heads in heads_by_layer.items()
+        }
+        self._head_index_tensors: dict[tuple[int, torch.device], torch.Tensor] = {}
+        self._prepared_mapping: torch.Tensor | None = None
+        self._unit_score_sum: torch.Tensor | None = None
+        self._recorded_head_count = 0
+
+    def heads_for_layer(self, layer_index: int) -> tuple[int, ...]:
+        return self._heads_by_layer.get(layer_index, ())
+
+    def head_indices_for_layer(self, layer_index: int, device: torch.device) -> torch.Tensor:
+        key = (layer_index, device)
+        indices = self._head_index_tensors.get(key)
+        if indices is None:
+            indices = torch.tensor(
+                self.heads_for_layer(layer_index), dtype=torch.long, device=device
+            )
+            self._head_index_tensors[key] = indices
+        return indices
+
+    def begin_frame(self) -> None:
+        self._unit_score_sum = None
+        self._recorded_head_count = 0
+
+    def capture_attention(self, layer_index: int, query: torch.Tensor, keys: torch.Tensor) -> None:
+        """Extract configured head scores from projected attention inputs."""
+        if query.shape[2] != 1:
+            return
+        selected_heads = self.heads_for_layer(layer_index)
+        if not selected_heads:
+            return
+
+        text_keys = keys[:, :, self.text_start : self.text_end]
+        if len(selected_heads) == 1:
+            head = selected_heads[0]
+            selected_query = query[:, head, 0]
+            selected_keys = text_keys[:, head]
+            if query.shape[0] == 1:
+                logits = torch.mv(selected_keys[0], selected_query[0])[None, None]
+            else:
+                logits = torch.bmm(selected_keys, selected_query.unsqueeze(-1)).squeeze(-1)[:, None]
+        else:
+            head_indices = self.head_indices_for_layer(layer_index, query.device)
+            selected_query = query.index_select(1, head_indices)[:, :, 0]
+            selected_keys = text_keys.index_select(1, head_indices)
+            logits = torch.einsum("bhd,bhtd->bht", selected_query, selected_keys)
+
+        logits = logits / query.shape[-1] ** 0.5
+        attention = torch.softmax(logits.float(), dim=-1).to(query.dtype)
+        self.record(layer_index, selected_heads, attention)
+
+    def record(
+        self, layer_index: int, head_indices: tuple[int, ...], attention: torch.Tensor
+    ) -> None:
+        if head_indices != self.heads_for_layer(layer_index):
+            raise RuntimeError(f"Unexpected timestamp heads captured for layer {layer_index}")
+        mapping = self._prepared_mapping
+        if (
+            mapping is None
+            or mapping.device != attention.device
+            or mapping.dtype != attention.dtype
+        ):
+            mapping = self.token_to_unit.to(device=attention.device, dtype=attention.dtype)
+            self._prepared_mapping = mapping
+        reduced = torch.matmul(attention, mapping).sum(dim=1)
+        self._unit_score_sum = (
+            reduced if self._unit_score_sum is None else self._unit_score_sum + reduced
+        )
+        self._recorded_head_count += len(head_indices)
+
+    def finish_frame(self) -> torch.Tensor:
+        if self._unit_score_sum is None or self._recorded_head_count != len(self.heads):
+            raise RuntimeError("Timestamp attention was not captured for every configured head")
+        return (self._unit_score_sum[0] / self._recorded_head_count).detach()
+
+
+class WordAlignment:
+    def __init__(self, units: tuple[_TextUnit, ...]):
+        self.units = units
+        self._word_unit_indices = [
+            unit_index for unit_index, unit in enumerate(units) if unit.is_word
+        ]
+        self._next_word_position = 0
+        self._open_word_position: int | None = None
+        self._open_start: float | None = None
+
+    def _word(self, position: int) -> _SourceWord:
+        word = self.units[self._word_unit_indices[position]].word
+        assert word is not None
+        return word
+
+    def _open_next(self, timestamp: float) -> WordStart:
+        position = self._next_word_position
+        word = self._word(position)
+        self._open_word_position = position
+        self._open_start = timestamp
+        self._next_word_position = position + 1
+        return WordStart(word.text, word.word_index, timestamp)
+
+    def _close(self, timestamp: float) -> WordEnd:
+        assert self._open_word_position is not None and self._open_start is not None
+        word = self._word(self._open_word_position)
+        event = WordEnd(word.text, word.word_index, self._open_start, timestamp)
+        self._open_word_position = None
+        self._open_start = None
+        return event
+
+    def _future_word_dominates(self, scores: torch.Tensor, current_unit: int) -> bool:
+        current_score = scores[current_unit].item()
+        next_unit = self._word_unit_indices[self._next_word_position]
+        if scores[next_unit].item() > current_score:
+            return True
+        if current_score >= _NON_NEXT_ATTENTION_THRESHOLD:
+            return False
+        later_units = self._word_unit_indices[self._next_word_position + 1 :]
+        return any(scores[unit].item() > current_score for unit in later_units)
+
+    def process_frame(
+        self, scores: torch.Tensor, voiced: bool, frame_start: float
+    ) -> list[WordStart | WordEnd]:
+        if scores.shape != (len(self.units),):
+            raise ValueError(
+                f"Expected {len(self.units)} timestamp unit scores, got {tuple(scores.shape)}"
+            )
+        events: list[WordStart | WordEnd] = []
+
+        if not voiced:
+            if self._open_word_position is None:
+                return events
+            current_unit = self._word_unit_indices[self._open_word_position]
+            future = scores[current_unit + 1 :]
+            should_close = (
+                bool(future.numel()) and future.max().item() > scores[current_unit].item()
+            )
+            is_final_word = self._open_word_position == len(self._word_unit_indices) - 1
+            has_later_punctuation = any(
+                not unit.is_word and not unit.synthetic for unit in self.units[current_unit + 1 :]
+            )
+            if should_close or (is_final_word and not has_later_punctuation):
+                events.append(self._close(frame_start))
+            return events
+
+        if self._open_word_position is None:
+            if self._next_word_position >= len(self._word_unit_indices):
+                return events
+            events.append(self._open_next(frame_start))
+            return events
+
+        current_unit = self._word_unit_indices[self._open_word_position]
+        if self._next_word_position >= len(self._word_unit_indices):
+            return events
+        if self._future_word_dominates(scores, current_unit):
+            events.append(self._close(frame_start))
+            events.append(self._open_next(frame_start))
+        return events
+
+    def finish(self, audio_end: float) -> list[WordEnd]:
+        events: list[WordEnd] = []
+        if self._open_word_position is not None:
+            events.append(self._close(audio_end))
+        self._next_word_position = len(self._word_unit_indices)
+        return events

--- a/pocket_tts/timestamps/records.py
+++ b/pocket_tts/timestamps/records.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass(frozen=True, slots=True)
+class AudioChunk:
+    audio: torch.Tensor
+    start_time: float
+    end_time: float
+
+
+@dataclass(frozen=True, slots=True)
+class WordStart:
+    word: str
+    word_index: int
+    start_time: float
+
+
+@dataclass(frozen=True, slots=True)
+class WordEnd:
+    word: str
+    word_index: int
+    start_time: float
+    end_time: float
+
+
+@dataclass(frozen=True, slots=True)
+class WordTimestamp:
+    word: str
+    word_index: int
+    start_time: float
+    end_time: float
+
+
+@dataclass(frozen=True, slots=True)
+class TimestampedAudio:
+    audio: torch.Tensor
+    words: tuple[WordTimestamp, ...]
+
+
+TimestampEvent = AudioChunk | WordStart | WordEnd

--- a/pocket_tts/timestamps/text.py
+++ b/pocket_tts/timestamps/text.py
@@ -1,0 +1,741 @@
+from __future__ import annotations
+
+import logging
+import unicodedata
+from collections import Counter
+from dataclasses import dataclass
+from itertools import groupby
+from typing import Any, Literal
+
+import torch
+from beartype.typing import Callable, Iterable, Iterator
+
+
+@dataclass(frozen=True, slots=True)
+class _SourceWord:
+    text: str
+    word_index: int
+    begin: int
+    end: int
+
+
+@dataclass(frozen=True, slots=True)
+class _TextUnit:
+    text: str
+    chunk_begin: int
+    chunk_end: int
+    word: _SourceWord | None
+    synthetic: bool = False
+
+    @property
+    def is_word(self) -> bool:
+        return self.word is not None
+
+
+@dataclass(frozen=True, slots=True)
+class TimestampTextChunk:
+    text: str
+    units: tuple[_TextUnit, ...]
+    token_to_unit: torch.Tensor
+    prepared_tokens: torch.Tensor | None = None
+
+    @property
+    def words(self) -> tuple[_SourceWord, ...]:
+        return tuple(unit.word for unit in self.units if unit.word is not None)
+
+
+@dataclass(frozen=True, slots=True)
+class _Span:
+    begin: int
+    end: int
+
+
+@dataclass(frozen=True, slots=True)
+class _CanonicalProjection:
+    text: str
+    origins: tuple[_Span, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _ChunkOrigin:
+    chunk_index: int
+    chunk_begin: int
+    chunk_end: int
+
+
+@dataclass(frozen=True, slots=True)
+class _CanonicalGroup:
+    chunk_index: int
+    canonical_begin: int
+    canonical_end: int
+
+
+@dataclass(frozen=True, slots=True)
+class _WordPart:
+    text: str
+    source_begin: int
+    source_end: int
+    group: _CanonicalGroup
+
+
+@dataclass(frozen=True, slots=True)
+class _MappedWord:
+    word: _SourceWord
+    chunk_span: _Span
+
+
+@dataclass(frozen=True, slots=True)
+class _PreparedWord:
+    chunk_index: int
+    span: _Span
+    normalized: str
+
+
+@dataclass(frozen=True, slots=True)
+class _PieceLayout:
+    spans: tuple[_Span, ...]
+    coordinate_system: Literal["byte", "codepoint"]
+    token_ids: tuple[int, ...]
+
+
+_FOLD_TRANSLATION = str.maketrans({"’": "'", "‐": "-", "‑": "-"})
+_CANONICAL_WORD_CHARACTERS = frozenset("'-")
+_WORD_CONTINUATIONS = frozenset("-‐‑'’")
+
+logger = logging.getLogger(__name__)
+
+
+def _fold(text: str) -> str:
+    return text.casefold().translate(_FOLD_TRANSLATION)
+
+
+def _is_canonical_word_character(character: str) -> bool:
+    return character.isalnum() or character in _CANONICAL_WORD_CHARACTERS
+
+
+def _normalized_word(text: str) -> str:
+    normalized = _fold(unicodedata.normalize("NFKC", text))
+    return "".join(character for character in normalized if _is_canonical_word_character(character))
+
+
+def _is_word_character(character: str) -> bool:
+    return character.isalnum()
+
+
+def _is_combining_mark(character: str) -> bool:
+    return unicodedata.category(character).startswith("M")
+
+
+def _lexical_word_spans(text: str) -> list[_Span]:
+    """Return lexical spans, retaining combining marks with their base character."""
+
+    spans: list[_Span] = []
+    index = 0
+    while index < len(text):
+        if not _is_word_character(text[index]):
+            index += 1
+            continue
+
+        begin = index
+        while True:
+            while index < len(text) and (
+                _is_word_character(text[index]) or _is_combining_mark(text[index])
+            ):
+                index += 1
+            if (
+                index + 1 < len(text)
+                and text[index] in _WORD_CONTINUATIONS
+                and _is_word_character(text[index + 1])
+            ):
+                index += 1
+                continue
+            break
+        if _normalized_word(text[begin:index]):
+            spans.append(_Span(begin, index))
+    return spans
+
+
+def _lexical_words(text: str) -> list[_SourceWord]:
+    return [
+        _SourceWord(
+            text=text[span.begin : span.end], word_index=index, begin=span.begin, end=span.end
+        )
+        for index, span in enumerate(_lexical_word_spans(text))
+    ]
+
+
+def _byte_piece_value(piece: str) -> int | None:
+    if len(piece) != 6 or not piece.startswith("<0x") or not piece.endswith(">"):
+        return None
+    try:
+        return int(piece[3:5], 16)
+    except ValueError:
+        return None
+
+
+def _utf8_sequence_length(first_byte: int) -> int:
+    if first_byte < 0x80:
+        return 1
+    if 0xC2 <= first_byte <= 0xDF:
+        return 2
+    if 0xE0 <= first_byte <= 0xEF:
+        return 3
+    if 0xF0 <= first_byte <= 0xF4:
+        return 4
+    return 1
+
+
+def _expand_byte_fallback_spans(
+    spans: tuple[_Span, ...], pieces: tuple[str, ...]
+) -> tuple[_Span, ...]:
+    """Give every byte piece for one Unicode scalar the scalar's complete span."""
+
+    expanded = list(spans)
+    index = 0
+    while index < len(pieces):
+        first_byte = _byte_piece_value(pieces[index])
+        if first_byte is None:
+            index += 1
+            continue
+
+        sequence_length = _utf8_sequence_length(first_byte)
+        byte_values = [
+            _byte_piece_value(piece) for piece in pieces[index : index + sequence_length]
+        ]
+        valid_sequence = (
+            len(byte_values) == sequence_length
+            and None not in byte_values
+            and all(0x80 <= value <= 0xBF for value in byte_values[1:])
+        )
+        end = index + sequence_length if valid_sequence else index + 1
+
+        begin_offset = min(span.begin for span in spans[index:end])
+        end_offset = max(span.end for span in spans[index:end])
+        if end_offset > begin_offset:
+            expanded[index:end] = [_Span(begin_offset, end_offset)] * (end - index)
+        index = end
+    return tuple(expanded)
+
+
+class _SentencePieceLayoutReader:
+    def __init__(self, processor: Any):
+        self._processor = processor
+        self._reader: Callable[[str], _PieceLayout] | None = None
+
+    def read(self, text: str) -> _PieceLayout:
+        if self._reader is not None:
+            return self._reader(text)
+
+        try:
+            encoded = self._processor.encode(text, return_type="offset_mapping", return_bytes=True)
+        except TypeError:
+            self._reader = self._from_immutable_proto
+            return self._reader(text)
+
+        self._reader = self._from_offset_mapping
+        return self._parse_offset_mapping(encoded)
+
+    def _from_offset_mapping(self, text: str) -> _PieceLayout:
+        encoded = self._processor.encode(text, return_type="offset_mapping", return_bytes=True)
+        return self._parse_offset_mapping(encoded)
+
+    def _parse_offset_mapping(self, encoded: object) -> _PieceLayout:
+        if not isinstance(encoded, dict):
+            raise TypeError("SentencePiece offset_mapping must return a dictionary")
+        offsets = encoded.get("offsets")
+        token_ids = encoded.get("ids")
+        if not isinstance(offsets, list) or not isinstance(token_ids, list):
+            raise TypeError("SentencePiece offset_mapping must contain list ids and offsets")
+        if len(offsets) != len(token_ids):
+            raise ValueError("SentencePiece offset_mapping ids and offsets have different lengths")
+        try:
+            spans = tuple(_Span(int(begin), int(end)) for begin, end in offsets)
+        except (TypeError, ValueError) as error:
+            raise TypeError(
+                "SentencePiece offset_mapping offsets must be begin/end pairs"
+            ) from error
+
+        pieces = encoded.get("pieces")
+        if not isinstance(pieces, list):
+            pieces = [self._processor.id_to_piece(token_id) for token_id in token_ids]
+        if len(pieces) != len(spans):
+            raise ValueError(
+                "SentencePiece offset_mapping pieces and offsets have different lengths"
+            )
+        piece_texts = tuple(
+            piece.decode("utf-8") if isinstance(piece, bytes) else str(piece) for piece in pieces
+        )
+        return _PieceLayout(
+            _expand_byte_fallback_spans(spans, piece_texts),
+            "byte",
+            tuple(int(token_id) for token_id in token_ids),
+        )
+
+    def _from_immutable_proto(self, text: str) -> _PieceLayout:
+        proto = self._processor.encode(text, out_type="immutable_proto")
+        spans = tuple(_Span(int(piece.begin), int(piece.end)) for piece in proto.pieces)
+        pieces = tuple(str(piece.piece) for piece in proto.pieces)
+        token_ids = tuple(int(piece.id) for piece in proto.pieces)
+        return _PieceLayout(_expand_byte_fallback_spans(spans, pieces), "codepoint", token_ids)
+
+
+def _canonical_characters(text: str) -> _CanonicalProjection:
+    """Return canonical text and each character's span in the input text."""
+
+    normalized = ""
+    normalized_origins: list[_Span] = []
+
+    for index in range(len(text)):
+        updated = unicodedata.normalize("NFKC", text[: index + 1])
+        common = 0
+        while (
+            common < len(normalized)
+            and common < len(updated)
+            and normalized[common] == updated[common]
+        ):
+            common += 1
+        changed_origins = [*normalized_origins[common:], _Span(index, index + 1)]
+        changed_origin = _Span(
+            min(origin.begin for origin in changed_origins),
+            max(origin.end for origin in changed_origins),
+        )
+        normalized_origins = [
+            *normalized_origins[:common],
+            *([changed_origin] * (len(updated) - common)),
+        ]
+        normalized = updated
+
+    characters: list[str] = []
+    origins: list[_Span] = []
+    for character, origin in zip(normalized, normalized_origins):
+        for folded_character in _fold(character):
+            if _is_canonical_word_character(folded_character):
+                characters.append(folded_character)
+                origins.append(origin)
+    return _CanonicalProjection("".join(characters), tuple(origins))
+
+
+def _capitalization_variants(text: str) -> tuple[str, ...]:
+    if not text:
+        return (text,)
+    return tuple(dict.fromkeys((text, text[0].upper() + text[1:])))
+
+
+def _surface_span(
+    source_text: str, chunk_text: str, canonical_span: _Span, capitalize: bool
+) -> _Span:
+    candidates = _capitalization_variants(source_text) if capitalize else (source_text,)
+    surface_matches: list[_Span] = []
+    for candidate in candidates:
+        surface = unicodedata.normalize("NFKC", candidate)
+        surface_begin = chunk_text.find(surface)
+        while surface_begin >= 0:
+            surface_span = _Span(surface_begin, surface_begin + len(surface))
+            if (
+                surface_span.begin <= canonical_span.begin
+                and canonical_span.end <= surface_span.end
+            ):
+                surface_matches.append(surface_span)
+            surface_begin = chunk_text.find(surface, surface_begin + 1)
+
+    if surface_matches:
+        canonical_span = min(
+            surface_matches,
+            key=lambda span: (
+                canonical_span.begin - span.begin + span.end - canonical_span.end,
+                span.begin,
+            ),
+        )
+    chunk_end = canonical_span.end
+    while chunk_end < len(chunk_text) and _is_combining_mark(chunk_text[chunk_end]):
+        chunk_end += 1
+    return _Span(canonical_span.begin, chunk_end)
+
+
+def _build_canonical_index(normalized_chunks: list[str]) -> tuple[str, tuple[_ChunkOrigin, ...]]:
+    canonical_parts: list[str] = []
+    origins: list[_ChunkOrigin] = []
+    for chunk_index, chunk in enumerate(normalized_chunks):
+        projection = _canonical_characters(chunk)
+        canonical_parts.append(projection.text)
+        origins.extend(
+            _ChunkOrigin(chunk_index, origin.begin, origin.end) for origin in projection.origins
+        )
+    return "".join(canonical_parts), tuple(origins)
+
+
+def _validate_canonical_source(source_text: str, canonical_text: str) -> None:
+    stripped_source = source_text.strip()
+    canonical_variants = {
+        _normalized_word(variant) for variant in _capitalization_variants(stripped_source)
+    }
+    if canonical_text not in canonical_variants:
+        raise ValueError("Prepared timestamp text does not match the original input")
+
+
+def _find_word_in_canonical_text(
+    canonical_text: str, candidates: tuple[str, ...], minimum_begin: int
+) -> _Span:
+    matches: list[_Span] = []
+    for candidate in candidates:
+        begin = canonical_text.find(candidate, minimum_begin)
+        if begin >= 0:
+            matches.append(_Span(begin, begin + len(candidate)))
+    if not matches:
+        raise ValueError("Prepared timestamp text does not contain an input word")
+    return min(matches, key=lambda match: match.begin)
+
+
+def _canonical_groups(
+    canonical_span: _Span, origins: tuple[_ChunkOrigin, ...]
+) -> tuple[_CanonicalGroup, ...]:
+    groups = []
+    positions = range(canonical_span.begin, canonical_span.end)
+    for chunk_index, grouped_positions in groupby(
+        positions, key=lambda position: origins[position].chunk_index
+    ):
+        grouped_positions = tuple(grouped_positions)
+        groups.append(_CanonicalGroup(chunk_index, grouped_positions[0], grouped_positions[-1] + 1))
+    return tuple(groups)
+
+
+def _split_word_across_chunks(
+    source_word: _SourceWord,
+    canonical_span: _Span,
+    source_projection: _CanonicalProjection,
+    chunk_origins: tuple[_ChunkOrigin, ...],
+) -> tuple[_WordPart, ...]:
+    if len(source_projection.origins) != canonical_span.end - canonical_span.begin:
+        raise ValueError(f"Cannot project input word {source_word.text!r} onto prepared text")
+
+    groups = _canonical_groups(canonical_span, chunk_origins)
+    source_begins = [
+        min(
+            origin.begin
+            for origin in source_projection.origins[
+                group.canonical_begin - canonical_span.begin : group.canonical_end
+                - canonical_span.begin
+            ]
+        )
+        for group in groups
+    ]
+    if any(
+        next_begin <= current_begin
+        for current_begin, next_begin in zip(source_begins, source_begins[1:])
+    ):
+        raise ValueError(f"Prepared chunks split input character in {source_word.text!r}")
+
+    parts = []
+    for group_index, group in enumerate(groups):
+        relative_begin = 0 if group_index == 0 else source_begins[group_index]
+        relative_end = (
+            source_begins[group_index + 1]
+            if group_index + 1 < len(groups)
+            else len(source_word.text)
+        )
+        parts.append(
+            _WordPart(
+                text=source_word.text[relative_begin:relative_end],
+                source_begin=source_word.begin + relative_begin,
+                source_end=source_word.begin + relative_end,
+                group=group,
+            )
+        )
+    return tuple(parts)
+
+
+def _map_source_words_to_chunks(
+    source_text: str, normalized_chunks: list[str], source_words: list[_SourceWord]
+) -> list[list[_MappedWord]]:
+    canonical_text, chunk_origins = _build_canonical_index(normalized_chunks)
+    _validate_canonical_source(source_text, canonical_text)
+
+    mapped: list[list[_MappedWord]] = [[] for _ in normalized_chunks]
+    minimum_begin = 0
+    next_word_index = 0
+    for source_word in source_words:
+        canonical_word = _normalized_word(source_word.text)
+        candidates = (canonical_word,)
+        if source_word.word_index == 0:
+            candidates = tuple(
+                dict.fromkeys(
+                    _normalized_word(variant)
+                    for variant in _capitalization_variants(source_word.text)
+                )
+            )
+        canonical_span = _find_word_in_canonical_text(canonical_text, candidates, minimum_begin)
+        if canonical_span.begin == canonical_span.end:
+            raise ValueError(f"Input word {source_word.text!r} has no timestamp text")
+
+        source_projection = _canonical_characters(source_word.text)
+        parts = _split_word_across_chunks(
+            source_word, canonical_span, source_projection, chunk_origins
+        )
+        for part_index, part in enumerate(parts):
+            word = _SourceWord(
+                text=part.text,
+                word_index=next_word_index,
+                begin=part.source_begin,
+                end=part.source_end,
+            )
+            next_word_index += 1
+            canonical_chunk_span = _Span(
+                chunk_origins[part.group.canonical_begin].chunk_begin,
+                chunk_origins[part.group.canonical_end - 1].chunk_end,
+            )
+            chunk_span = _surface_span(
+                part.text,
+                normalized_chunks[part.group.chunk_index],
+                canonical_chunk_span,
+                capitalize=source_word.word_index == 0 and part_index == 0,
+            )
+            mapped[part.group.chunk_index].append(_MappedWord(word, chunk_span))
+        minimum_begin = canonical_span.end
+    return mapped
+
+
+def _punctuation_spans(text: str, covered: list[bool]) -> list[_Span]:
+    spans: list[_Span] = []
+    index = 0
+    while index < len(text):
+        is_punctuation = not covered[index] and unicodedata.category(text[index]).startswith("P")
+        if not is_punctuation:
+            index += 1
+            continue
+        end = index + 1
+        while (
+            end < len(text) and not covered[end] and unicodedata.category(text[end]).startswith("P")
+        ):
+            end += 1
+        spans.append(_Span(index, end))
+        index = end
+    return spans
+
+
+def _is_synthetic_punctuation(
+    source_text: str,
+    source_words: list[_SourceWord],
+    chunk_words: list[_MappedWord],
+    punctuation_span: _Span,
+) -> bool:
+    if not chunk_words or punctuation_span.begin < chunk_words[-1].chunk_span.end:
+        return False
+    last_word = chunk_words[-1].word
+    next_word_index = last_word.word_index + 1
+    source_boundary_end = (
+        source_words[next_word_index].begin
+        if next_word_index < len(source_words)
+        else len(source_text)
+    )
+    source_trailing_text = source_text[last_word.end : source_boundary_end]
+    return not any(
+        unicodedata.category(character).startswith("P") for character in source_trailing_text
+    )
+
+
+def _build_units(
+    source_text: str,
+    source_words: list[_SourceWord],
+    normalized_chunk: str,
+    chunk_words: list[_MappedWord],
+    ignored_spans: tuple[_Span, ...] = (),
+) -> tuple[_TextUnit, ...]:
+    units: list[_TextUnit] = []
+    covered = [False] * len(normalized_chunk)
+    for mapped_word in chunk_words:
+        span = mapped_word.chunk_span
+        units.append(
+            _TextUnit(
+                text=mapped_word.word.text,
+                chunk_begin=span.begin,
+                chunk_end=span.end,
+                word=mapped_word.word,
+            )
+        )
+        covered[span.begin : span.end] = [True] * (span.end - span.begin)
+
+    for span in ignored_spans:
+        units.append(
+            _TextUnit(
+                text=normalized_chunk[span.begin : span.end],
+                chunk_begin=span.begin,
+                chunk_end=span.end,
+                word=None,
+                synthetic=True,
+            )
+        )
+        covered[span.begin : span.end] = [True] * (span.end - span.begin)
+
+    for span in _punctuation_spans(normalized_chunk, covered):
+        units.append(
+            _TextUnit(
+                text=normalized_chunk[span.begin : span.end],
+                chunk_begin=span.begin,
+                chunk_end=span.end,
+                word=None,
+                synthetic=_is_synthetic_punctuation(source_text, source_words, chunk_words, span),
+            )
+        )
+    units.sort(key=lambda unit: (unit.chunk_begin, unit.chunk_end))
+    return tuple(units)
+
+
+def _unit_spans(
+    text: str, units: tuple[_TextUnit, ...], coordinate_system: Literal["byte", "codepoint"]
+) -> list[_Span]:
+    if coordinate_system == "codepoint":
+        return [_Span(unit.chunk_begin, unit.chunk_end) for unit in units]
+
+    byte_boundaries = [0]
+    for character in text:
+        byte_boundaries.append(byte_boundaries[-1] + len(character.encode("utf-8")))
+    return [
+        _Span(byte_boundaries[unit.chunk_begin], byte_boundaries[unit.chunk_end]) for unit in units
+    ]
+
+
+def _token_to_unit_mapping(
+    text: str, units: tuple[_TextUnit, ...], piece_layout: _PieceLayout
+) -> torch.Tensor:
+    unit_spans = _unit_spans(text, units, piece_layout.coordinate_system)
+    shape = (len(piece_layout.spans), len(unit_spans))
+    if not piece_layout.spans or not unit_spans:
+        return torch.zeros(shape, dtype=torch.float32)
+
+    piece_begins = torch.tensor([span.begin for span in piece_layout.spans])[:, None]
+    piece_ends = torch.tensor([span.end for span in piece_layout.spans])[:, None]
+    unit_begins = torch.tensor([span.begin for span in unit_spans])[None, :]
+    unit_ends = torch.tensor([span.end for span in unit_spans])[None, :]
+    overlaps = (
+        torch.minimum(piece_ends, unit_ends) - torch.maximum(piece_begins, unit_begins)
+    ).clamp_min(0)
+    overlaps = overlaps.to(torch.float32)
+    totals = overlaps.sum(dim=1, keepdim=True)
+    return torch.where(totals > 0, overlaps / totals.clamp_min(1), overlaps)
+
+
+def _prepared_words(normalized_chunks: list[str]) -> list[_PreparedWord]:
+    return [
+        _PreparedWord(
+            chunk_index=chunk_index,
+            span=span,
+            normalized=_normalized_word(chunk[span.begin : span.end]),
+        )
+        for chunk_index, chunk in enumerate(normalized_chunks)
+        for span in _lexical_word_spans(chunk)
+    ]
+
+
+def _fast_map_source_words_to_chunks(
+    source_words: list[_SourceWord], prepared_words: list[_PreparedWord], chunk_count: int
+) -> list[list[_MappedWord]] | None:
+    if len(source_words) != len(prepared_words):
+        return None
+    if any(
+        _normalized_word(source_word.text) != prepared_word.normalized
+        for source_word, prepared_word in zip(source_words, prepared_words)
+    ):
+        return None
+
+    mapped: list[list[_MappedWord]] = [[] for _ in range(chunk_count)]
+    for source_word, prepared_word in zip(source_words, prepared_words):
+        mapped[prepared_word.chunk_index].append(_MappedWord(source_word, prepared_word.span))
+    return mapped
+
+
+def _best_effort_map_source_words_to_chunks(
+    source_words: list[_SourceWord], prepared_words: list[_PreparedWord], chunk_count: int
+) -> tuple[list[list[_MappedWord]], list[tuple[_Span, ...]], int]:
+    """Map only unique monotonic word pairs so degraded timestamps never guess."""
+
+    source_keys = [_normalized_word(word.text) for word in source_words]
+    prepared_keys = [word.normalized for word in prepared_words]
+    source_counts = Counter(source_keys)
+    prepared_counts = Counter(prepared_keys)
+    prepared_positions = {key: index for index, key in enumerate(prepared_keys)}
+
+    pairs: list[tuple[int, int]] = []
+    previous_prepared = -1
+    for source_index, key in enumerate(source_keys):
+        if source_counts[key] != 1 or prepared_counts[key] != 1:
+            continue
+        prepared_index = prepared_positions[key]
+        if prepared_index <= previous_prepared:
+            continue
+        pairs.append((source_index, prepared_index))
+        previous_prepared = prepared_index
+
+    mapped: list[list[_MappedWord]] = [[] for _ in range(chunk_count)]
+    paired_prepared = set()
+    paired_source = set()
+    for source_index, prepared_index in pairs:
+        source_word = source_words[source_index]
+        prepared_word = prepared_words[prepared_index]
+        mapped[prepared_word.chunk_index].append(_MappedWord(source_word, prepared_word.span))
+        paired_source.add(source_index)
+        paired_prepared.add(prepared_index)
+
+    ignored: list[list[_Span]] = [[] for _ in range(chunk_count)]
+    for prepared_index, prepared_word in enumerate(prepared_words):
+        if prepared_index not in paired_prepared:
+            ignored[prepared_word.chunk_index].append(prepared_word.span)
+    return mapped, [tuple(spans) for spans in ignored], len(source_words) - len(paired_source)
+
+
+def _iter_timestamp_text_chunks(
+    source_text: str,
+    chunks: Iterable[str],
+    sentencepiece_processor: Any,
+    *,
+    best_effort: bool = False,
+) -> Iterator[TimestampTextChunk]:
+    """Lazily map prepared chunks, retaining strict behavior unless requested."""
+
+    lexical_words = _lexical_words(source_text)
+    normalized_chunks = [unicodedata.normalize("NFKC", chunk) for chunk in chunks]
+    prepared_words = _prepared_words(normalized_chunks)
+    mapped_words = _fast_map_source_words_to_chunks(
+        lexical_words, prepared_words, len(normalized_chunks)
+    )
+    ignored_spans: list[tuple[_Span, ...]] = [() for _ in normalized_chunks]
+    source_words = lexical_words
+
+    if mapped_words is None:
+        try:
+            mapped_words = _map_source_words_to_chunks(
+                source_text, normalized_chunks, lexical_words
+            )
+            source_words = [mapped.word for chunk_words in mapped_words for mapped in chunk_words]
+        except ValueError:
+            if not best_effort:
+                raise
+            mapped_words, ignored_spans, omitted_count = _best_effort_map_source_words_to_chunks(
+                lexical_words, prepared_words, len(normalized_chunks)
+            )
+            logger.warning(
+                "Timestamp text mapping omitted %d source word(s); audio generation continues",
+                omitted_count,
+            )
+
+    piece_layout_reader = _SentencePieceLayoutReader(sentencepiece_processor)
+    for normalized_chunk, chunk_words, chunk_ignored in zip(
+        normalized_chunks, mapped_words, ignored_spans
+    ):
+        units = _build_units(
+            source_text, source_words, normalized_chunk, chunk_words, chunk_ignored
+        )
+        piece_layout = piece_layout_reader.read(normalized_chunk)
+        yield TimestampTextChunk(
+            text=normalized_chunk,
+            units=units,
+            token_to_unit=_token_to_unit_mapping(normalized_chunk, units, piece_layout),
+            prepared_tokens=torch.tensor(piece_layout.token_ids, dtype=torch.long)[None, :],
+        )
+
+
+def build_timestamp_text_chunks(
+    source_text: str, chunks: Iterable[str], sentencepiece_processor: Any
+) -> list[TimestampTextChunk]:
+    """Map prepared generation chunks back to exact lexical spans in source text."""
+
+    return list(_iter_timestamp_text_chunks(source_text, chunks, sentencepiece_processor))

--- a/pocket_tts/utils/config.py
+++ b/pocket_tts/utils/config.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 import yaml
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from pocket_tts.utils.utils import download_if_necessary
 
@@ -113,6 +113,11 @@ class MimiConfig(StrictModel):
     outer_dim: int | None = None
 
 
+class TimestampHeadConfig(StrictModel):
+    layer: int
+    head: int
+
+
 class Config(StrictModel):
     flow_lm: FlowLMConfig
     mimi: MimiConfig
@@ -122,6 +127,27 @@ class Config(StrictModel):
     remove_semicolons: bool = False
     model_recommended_frames_after_eos: int | None = None
     default_temperature: float = 0.7
+    timestamp_heads: list[TimestampHeadConfig] | None = None
+
+    @model_validator(mode="after")
+    def validate_timestamp_heads(self):
+        if self.timestamp_heads is None:
+            return self
+        if not self.timestamp_heads:
+            raise ValueError("timestamp_heads must contain at least one layer/head pair")
+        seen: set[tuple[int, int]] = set()
+        for selected in self.timestamp_heads:
+            pair = (selected.layer, selected.head)
+            if selected.layer < 0 or selected.layer >= self.flow_lm.transformer.num_layers:
+                raise ValueError(
+                    f"Timestamp layer {selected.layer} is outside the FlowLM layer range"
+                )
+            if selected.head < 0 or selected.head >= self.flow_lm.transformer.num_heads:
+                raise ValueError(f"Timestamp head {selected.head} is outside the FlowLM head range")
+            if pair in seen:
+                raise ValueError(f"Duplicate timestamp head L{selected.layer}H{selected.head}")
+            seen.add(pair)
+        return self
 
 
 def load_config(yaml_path: str | Path) -> Config:

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -5,8 +5,18 @@ from pocket_tts import TTSModel
 from pocket_tts.models.tts_model import TTSModel as TTSModelImpl
 
 
-def test_public_api_exports_only_tts_model():
-    assert pocket_tts.__all__ == ["TTSModel", "export_model_state"]
+def test_public_api_exports_expected_symbols():
+    expected_symbols = [
+        "AudioChunk",
+        "TimestampedAudio",
+        "TTSModel",
+        "WordEnd",
+        "WordStart",
+        "WordTimestamp",
+        "export_model_state",
+    ]
+    assert pocket_tts.__all__ == expected_symbols
+    assert all(hasattr(pocket_tts, symbol) for symbol in expected_symbols)
 
 
 def test_public_api_tts_model_points_to_implementation():
@@ -18,6 +28,8 @@ def test_public_api_expected_methods_and_properties():
         "load_model",
         "generate_audio",
         "generate_audio_stream",
+        "generate_audio_with_timestamps",
+        "generate_audio_with_timestamps_stream",
         "get_state_for_audio_prompt",
     ):
         assert callable(getattr(TTSModel, method_name))

--- a/tests/test_timestamp_text_mapping.py
+++ b/tests/test_timestamp_text_mapping.py
@@ -1,0 +1,287 @@
+import re
+import unicodedata
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from pocket_tts.models.tts_model import split_into_best_sentences
+from pocket_tts.modules.text_conditioner import LUTConditioner
+from pocket_tts.timestamps import build_timestamp_text_chunks
+from pocket_tts.timestamps.text import _iter_timestamp_text_chunks
+from pocket_tts.utils.config import CONFIGS_DIR, load_config
+
+BYTE_PIECE = re.compile(r"<0x[0-9A-F]{2}>")
+
+
+@pytest.fixture(scope="module")
+def conditioner():
+    lookup_table = load_config(CONFIGS_DIR / "english.yaml").flow_lm.lookup_table
+    return LUTConditioner(lookup_table.n_bins, lookup_table.tokenizer_path, dim=1, output_dim=1)
+
+
+def _timestamp_chunks(conditioner, source_text, *, max_tokens=100, remove_semicolons=False):
+    chunks = split_into_best_sentences(
+        conditioner.tokenizer,
+        source_text,
+        max_tokens,
+        pad_with_spaces_for_short_inputs=False,
+        remove_semicolons=remove_semicolons,
+    )
+    return build_timestamp_text_chunks(source_text, chunks, conditioner.tokenizer.sp)
+
+
+def _assert_mapping_contract(
+    conditioner, source_text, expected_words, *, prepared_chunks=None, **kwargs
+):
+    chunks = (
+        _timestamp_chunks(conditioner, source_text, **kwargs)
+        if prepared_chunks is None
+        else build_timestamp_text_chunks(source_text, prepared_chunks, conditioner.tokenizer.sp)
+    )
+    words = [word for chunk in chunks for word in chunk.words]
+
+    assert [word.text for word in words] == list(expected_words)
+    assert [word.word_index for word in words] == list(range(len(expected_words)))
+
+    for word in words:
+        assert source_text[word.begin : word.end] == word.text
+
+    for chunk in chunks:
+        prepared = conditioner.prepare(chunk.text)
+        expected_ids = conditioner.tokenizer.sp.encode(chunk.text, out_type=int)
+        assert prepared[0].tolist() == expected_ids
+        assert chunk.prepared_tokens is not None
+        assert chunk.prepared_tokens[0].tolist() == expected_ids
+        assert chunk.token_to_unit.shape == (len(expected_ids), len(chunk.units))
+        assert torch.isfinite(chunk.token_to_unit).all()
+        assert (chunk.token_to_unit >= 0).all()
+
+        row_sums = chunk.token_to_unit.sum(dim=1)
+        assert torch.all(
+            torch.isclose(row_sums, torch.zeros_like(row_sums))
+            | torch.isclose(row_sums, torch.ones_like(row_sums))
+        )
+
+        previous_end = 0
+        for unit in chunk.units:
+            assert 0 <= unit.chunk_begin < unit.chunk_end <= len(chunk.text)
+            assert unit.chunk_begin >= previous_end
+            previous_end = unit.chunk_end
+
+        for unit_index, _unit in enumerate(chunk.units):
+            assert chunk.token_to_unit[:, unit_index].sum() > 0
+
+    return chunks
+
+
+@pytest.mark.parametrize(
+    ("source_text", "expected_words", "remove_semicolons"),
+    [
+        ("  hello\n\r  world  ", ("hello", "world"), False),
+        ("first; second", ("first", "second"), True),
+        ("Café naïve.", ("Café", "naïve"), False),
+        (unicodedata.normalize("NFD", "Café naïve."), ("Cafe\u0301", "nai\u0308ve"), False),
+        ("A ﬁne result.", ("A", "ﬁne", "result"), False),
+        ("Ｆｕｌｌ ① test.", ("Ｆｕｌｌ", "①", "test"), False),
+        ("Roman Ⅷ test.", ("Roman", "Ⅷ", "test"), False),
+        ("5㈠ test.", ("5㈠", "test"), False),
+        ("It is 20℃.", ("It", "is", "20"), False),
+        ("Room №5.", ("Room", "5"), False),
+        ("Meet at ㏂ 10.", ("Meet", "at", "10"), False),
+        ("ıstanbul is here.", ("ıstanbul", "is", "here"), False),
+        ("ßtraße ǆungla σς.", ("ßtraße", "ǆungla", "σς"), False),
+        ("a\u0327\u0301 la carte.", ("a\u0327\u0301", "la", "carte"), False),
+        ("l’esprit isn't blue‑green.", ("l’esprit", "isn't", "blue‑green"), False),
+        ("Price_1 is 3.14—okay...", ("Price", "1", "is", "3", "14", "okay"), False),
+        ("Pay €5 😀 now。", ("Pay", "5", "now"), False),
+        ("zero\u200bwidth text.", ("zero", "width", "text"), False),
+        ("😀 €", (), False),
+    ],
+    ids=[
+        "preparation-whitespace",
+        "semicolon-replacement",
+        "nfc",
+        "nfd",
+        "ligature",
+        "full-width-and-circled",
+        "roman-numeral",
+        "parenthesized-ideograph",
+        "degree-celsius",
+        "numero-sign",
+        "am-symbol",
+        "initial-dotless-i",
+        "case-expansions",
+        "multiple-combining-marks",
+        "apostrophes-and-hyphens",
+        "word-boundaries",
+        "symbols",
+        "zero-width-boundary",
+        "no-lexical-words",
+    ],
+)
+def test_curated_text_mapping_contract(conditioner, source_text, expected_words, remove_semicolons):
+    _assert_mapping_contract(
+        conditioner, source_text, expected_words, remove_semicolons=remove_semicolons
+    )
+
+
+@pytest.mark.parametrize("source_text", ["A中B", "A𐐀B", "a\u0301\u0300"])
+def test_every_byte_fallback_piece_inside_a_word_is_mapped(conditioner, source_text):
+    chunks = _assert_mapping_contract(
+        conditioner, source_text, tuple(word for word in source_text.split() if word)
+    )
+    assert len(chunks) == 1
+    chunk = chunks[0]
+    pieces = conditioner.tokenizer.sp.encode(chunk.text, out_type=str)
+    byte_piece_indices = [
+        index for index, piece in enumerate(pieces) if BYTE_PIECE.fullmatch(piece)
+    ]
+
+    assert byte_piece_indices
+    word_unit = next(index for index, unit in enumerate(chunk.units) if unit.is_word)
+    assert torch.equal(
+        chunk.token_to_unit[byte_piece_indices, word_unit], torch.ones(len(byte_piece_indices))
+    )
+
+
+def test_canonical_equivalents_have_the_same_normalized_mapping(conditioner):
+    nfc_chunks = _assert_mapping_contract(conditioner, "Café naïve.", ("Café", "naïve"))
+    nfd_chunks = _assert_mapping_contract(
+        conditioner, unicodedata.normalize("NFD", "Café naïve."), ("Cafe\u0301", "nai\u0308ve")
+    )
+
+    assert [chunk.text for chunk in nfc_chunks] == [chunk.text for chunk in nfd_chunks]
+    for nfc, nfd in zip(nfc_chunks, nfd_chunks):
+        torch.testing.assert_close(nfc.token_to_unit, nfd.token_to_unit)
+
+
+def test_compatibility_punctuation_from_inside_a_word_stays_in_that_unit(conditioner):
+    chunk = _assert_mapping_contract(conditioner, "5㈠ test.", ("5㈠", "test"))[0]
+    first_word_unit = next(unit for unit in chunk.units if unit.is_word)
+    first_word = first_word_unit.word
+
+    assert first_word is not None
+    assert "5㈠ test."[first_word.begin : first_word.end] == "5㈠"
+    assert chunk.text[first_word_unit.chunk_begin : first_word_unit.chunk_end] == "5(一)"
+    assert [unit.text for unit in chunk.units if not unit.is_word] == ["."]
+
+
+@pytest.mark.parametrize(
+    ("source_text", "expected_punctuation", "expected_synthetic"),
+    [("hello world", ".", True), ("hello world!", "!", False)],
+)
+def test_only_preparation_added_terminal_punctuation_is_synthetic(
+    conditioner, source_text, expected_punctuation, expected_synthetic
+):
+    chunk = _timestamp_chunks(conditioner, source_text)[0]
+    punctuation = [unit for unit in chunk.units if not unit.is_word]
+
+    assert [(unit.text, unit.synthetic) for unit in punctuation] == [
+        (expected_punctuation, expected_synthetic)
+    ]
+
+
+def test_compatibility_punctuation_can_split_a_source_word_between_chunks(conditioner):
+    chunks = _assert_mapping_contract(
+        conditioner, "A⒚B 10.", ("A⒚", "B", "10"), prepared_chunks=["A19.", "B 10."]
+    )
+
+    assert [chunk.text for chunk in chunks] == ["A19.", "B 10."]
+
+
+def test_compatibility_character_that_normalizes_to_only_a_mark_is_not_a_word(conditioner):
+    _assert_mapping_contract(conditioner, "X ﾞ Y.", ("X", "Y"), max_tokens=8)
+
+
+def test_chunking_does_not_change_public_word_sequence(conditioner):
+    source_text = "Room №5. Meet at ㏂ 10. Café naïve; blue-green world!"
+    expected = ("Room", "5", "Meet", "at", "10", "Café", "naïve", "blue-green", "world")
+
+    results = []
+    for max_tokens in (8, 20, 100):
+        chunks = _assert_mapping_contract(conditioner, source_text, expected, max_tokens=max_tokens)
+        results.append([(word.word_index, word.text) for chunk in chunks for word in chunk.words])
+
+    assert results[0] == results[1] == results[2]
+
+
+@pytest.mark.parametrize("source_text", ["", " ", "\n\r"])
+def test_empty_text_has_the_same_rejection_as_ordinary_preprocessing(conditioner, source_text):
+    with pytest.raises(ValueError, match="empty"):
+        _timestamp_chunks(conditioner, source_text)
+
+
+def test_mapping_rejects_prepared_text_from_a_different_source(conditioner):
+    with pytest.raises(ValueError, match="does not match"):
+        build_timestamp_text_chunks("source words", ["Different words."], conditioner.tokenizer.sp)
+
+
+@pytest.mark.parametrize(
+    "source_text", ["Café naïve.", unicodedata.normalize("NFD", "Café naïve."), "A ﬁne result."]
+)
+def test_common_unicode_mapping_does_not_enter_robust_fallback(conditioner, source_text):
+    chunks = split_into_best_sentences(
+        conditioner.tokenizer,
+        source_text,
+        100,
+        pad_with_spaces_for_short_inputs=False,
+        remove_semicolons=False,
+    )
+    with patch(
+        "pocket_tts.timestamps.text._map_source_words_to_chunks",
+        side_effect=AssertionError("robust fallback should not run"),
+    ):
+        assert build_timestamp_text_chunks(source_text, chunks, conditioner.tokenizer.sp)
+
+
+def test_timestamp_chunk_mapping_tokenizes_later_chunks_lazily(conditioner):
+    class CountingProcessor:
+        def __init__(self, processor):
+            self.processor = processor
+            self.encoded_texts = []
+
+        def encode(self, text, *args, **kwargs):
+            self.encoded_texts.append(text)
+            return self.processor.encode(text, *args, **kwargs)
+
+        def __getattr__(self, name):
+            return getattr(self.processor, name)
+
+    processor = CountingProcessor(conditioner.tokenizer.sp)
+    iterator = _iter_timestamp_text_chunks("one two", ["One", "two."], processor, best_effort=True)
+    assert processor.encoded_texts == []
+
+    first = next(iterator)
+    assert first.text == "One"
+    assert processor.encoded_texts
+    assert set(processor.encoded_texts) == {"One"}
+
+    second = next(iterator)
+    assert second.text == "two."
+    assert "two." in processor.encoded_texts
+
+
+def test_product_mapping_degrades_to_unambiguous_gaps(conditioner):
+    with (
+        patch(
+            "pocket_tts.timestamps.text._map_source_words_to_chunks",
+            side_effect=ValueError("forced robust failure"),
+        ),
+        patch("pocket_tts.timestamps.text.logger.warning") as warning,
+    ):
+        chunks = list(
+            _iter_timestamp_text_chunks(
+                "one missing three",
+                ["One different three."],
+                conditioner.tokenizer.sp,
+                best_effort=True,
+            )
+        )
+
+    assert [word.word_index for word in chunks[0].words] == [0, 2]
+    ignored = [unit for unit in chunks[0].units if unit.synthetic and not unit.is_word]
+    assert any(unit.text == "different" for unit in ignored)
+    warning.assert_called_once_with(
+        "Timestamp text mapping omitted %d source word(s); audio generation continues", 1
+    )

--- a/tests/test_timestamps.py
+++ b/tests/test_timestamps.py
@@ -10,6 +10,7 @@ import sentencepiece
 import torch
 from torch import nn
 
+import pocket_tts.timestamps.alignment as timestamp_alignment
 from pocket_tts.models.tts_model import TTSModel
 from pocket_tts.modules.attention import StreamingMultiheadAttention
 from pocket_tts.modules.rope import RotaryEmbedding
@@ -124,25 +125,40 @@ def test_alignment_transitions_to_next_word_and_hard_finishes():
     assert final == [WordEnd("two", 1, 0.08, 0.16)]
 
 
-def test_later_word_evidence_below_gate_advances_one_word():
+@pytest.fixture
+def non_next_attention_gate(monkeypatch):
+    threshold = 0.1
+    monkeypatch.setattr(timestamp_alignment, "_NON_NEXT_ATTENTION_THRESHOLD", threshold)
+    return threshold
+
+
+def test_later_word_evidence_below_gate_advances_one_word(non_next_attention_gate):
     alignment = WordAlignment(_units("one", "two", "three"))
     alignment.process_frame(torch.tensor([0.9, 0.05, 0.05]), True, 0.0)
-    events = alignment.process_frame(torch.tensor([0.0009, 0.0001, 0.9]), True, 0.08)
+    events = alignment.process_frame(
+        torch.tensor([non_next_attention_gate / 2, 0.01, 0.9]), True, 0.08
+    )
 
     assert events == [WordEnd("one", 0, 0.0, 0.08), WordStart("two", 1, 0.08)]
 
 
-def test_non_next_evidence_is_blocked_at_gate_threshold():
+def test_non_next_evidence_above_gate_is_blocked(non_next_attention_gate):
     alignment = WordAlignment(_units("one", "two", "three"))
     alignment.process_frame(torch.tensor([0.9, 0.05, 0.05]), True, 0.0)
 
-    assert alignment.process_frame(torch.tensor([0.001, 0.0001, 0.9]), True, 0.08) == []
+    assert (
+        alignment.process_frame(torch.tensor([non_next_attention_gate * 2, 0.01, 0.9]), True, 0.08)
+        == []
+    )
 
 
-def test_non_next_evidence_uses_no_distance_margin():
+def test_non_next_evidence_uses_no_distance_margin(non_next_attention_gate):
     alignment = WordAlignment(_units("one", "two", "three", "four"))
     alignment.process_frame(torch.tensor([0.9, 0.05, 0.03, 0.02]), True, 0.0)
-    assert alignment.process_frame(torch.tensor([0.0009, 0.0001, 0.0001, 0.00091]), True, 0.08)
+    current_score = non_next_attention_gate / 2
+    assert alignment.process_frame(
+        torch.tensor([current_score, 0.01, 0.01, current_score * 1.01]), True, 0.08
+    )
 
 
 def test_gate_never_blocks_next_word_evidence():
@@ -168,10 +184,10 @@ def test_unpunctuated_final_word_closes_on_first_silence():
     ]
 
 
-@pytest.mark.parametrize(
-    ("amplitude", "expected"), [(0.001001, True), (0.001, False), (0.000999, False)]
-)
-def test_rms_silence_threshold_is_minus_60_dbfs(amplitude, expected):
+@pytest.mark.parametrize(("dbfs", "expected"), [(-59.0, True), (-61.0, False)])
+def test_rms_silence_gate_uses_configured_threshold(monkeypatch, dbfs, expected):
+    monkeypatch.setattr(timestamp_alignment, "_SILENCE_RMS_THRESHOLD", 10 ** (-60.0 / 20))
+    amplitude = 10 ** (dbfs / 20)
     assert is_voiced(torch.full((100,), amplitude)) is expected
 
 
@@ -180,8 +196,9 @@ def test_empty_audio_is_silent():
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.float32, torch.float64])
-def test_silence_detection_supports_non_contiguous_float_inputs(dtype):
-    samples = torch.full((200,), 0.001001, dtype=dtype)[::2]
+def test_silence_detection_supports_non_contiguous_float_inputs(monkeypatch, dtype):
+    monkeypatch.setattr(timestamp_alignment, "_SILENCE_RMS_THRESHOLD", 0.1)
+    samples = torch.full((200,), 0.2, dtype=dtype)[::2]
     assert not samples.is_contiguous()
     assert is_voiced(samples)
 
@@ -529,15 +546,20 @@ def test_degraded_word_gaps_preserve_audio_and_event_order():
 
 def test_timestamp_head_config_validation():
     config = load_config(CONFIGS_DIR / "english.yaml").model_dump()
-    config["timestamp_heads"] = [{"layer": 3, "head": 8}]
-    validated = Config(**config)
-    assert validated.timestamp_heads[0].layer == 3
+    transformer = config["flow_lm"]["transformer"]
+    last_layer = transformer["num_layers"] - 1
+    last_head = transformer["num_heads"] - 1
 
-    config["timestamp_heads"] = [{"layer": 6, "head": 0}]
+    config["timestamp_heads"] = [{"layer": last_layer, "head": last_head}]
+    validated = Config(**config)
+    assert validated.timestamp_heads[0].layer == last_layer
+    assert validated.timestamp_heads[0].head == last_head
+
+    config["timestamp_heads"] = [{"layer": transformer["num_layers"], "head": 0}]
     with pytest.raises(ValueError, match="outside the FlowLM layer range"):
         Config(**config)
 
-    config["timestamp_heads"] = [{"layer": 0, "head": 16}]
+    config["timestamp_heads"] = [{"layer": 0, "head": transformer["num_heads"]}]
     with pytest.raises(ValueError, match="outside the FlowLM head range"):
         Config(**config)
 

--- a/tests/test_timestamps.py
+++ b/tests/test_timestamps.py
@@ -1,0 +1,608 @@
+import copy
+import queue
+import threading
+import unicodedata
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import sentencepiece
+import torch
+from torch import nn
+
+from pocket_tts.models.tts_model import TTSModel
+from pocket_tts.modules.attention import StreamingMultiheadAttention
+from pocket_tts.modules.rope import RotaryEmbedding
+from pocket_tts.timestamps import (
+    AudioChunk,
+    SelectedAttentionCapture,
+    TimestampedAudio,
+    TimestampTextChunk,
+    WordAlignment,
+    WordEnd,
+    WordStart,
+    WordTimestamp,
+    _SourceWord,
+    _TextUnit,
+    build_timestamp_text_chunks,
+    is_voiced,
+)
+from pocket_tts.utils.config import CONFIGS_DIR, Config, load_config
+from pocket_tts.utils.utils import download_if_necessary
+
+
+class _SentencePiece021:
+    def encode(self, text, out_type):
+        assert out_type == "immutable_proto"
+        pieces = [
+            SimpleNamespace(
+                id=index, piece=character, surface=character, begin=index, end=index + 1
+            )
+            for index, character in enumerate(text)
+        ]
+        return SimpleNamespace(pieces=pieces)
+
+
+class _SentencePiece022:
+    def encode(self, text, return_type, return_bytes):
+        assert return_type == "offset_mapping"
+        assert return_bytes
+        offsets = []
+        byte_offset = 0
+        for character in text:
+            byte_end = byte_offset + len(character.encode("utf-8"))
+            offsets.append((byte_offset, byte_end))
+            byte_offset = byte_end
+        return {"ids": list(range(len(offsets))), "pieces": list(text), "offsets": offsets}
+
+
+def _units(*values):
+    units = []
+    word_index = 0
+    position = 0
+    for value in values:
+        if value.startswith("P:"):
+            text = value[2:]
+            units.append(_TextUnit(text, position, position + len(text), None))
+        else:
+            source = _SourceWord(value, word_index, position, position + len(value))
+            units.append(_TextUnit(value, position, position + len(value), source))
+            word_index += 1
+        position += len(value)
+    return tuple(units)
+
+
+def test_text_chunks_preserve_original_words_and_map_punctuation():
+    chunks = build_timestamp_text_chunks(
+        "hello, blue-green world!", ["Hello, blue-green world!"], _SentencePiece021()
+    )
+    assert len(chunks) == 1
+    chunk = chunks[0]
+    assert [word.text for word in chunk.words] == ["hello", "blue-green", "world"]
+    assert [unit.text for unit in chunk.units if not unit.is_word] == [",", "!"]
+    assert torch.all(chunk.token_to_unit.sum(dim=1) <= 1)
+
+
+def test_text_chunks_compare_sentencepiece_byte_offsets_with_utf8_unit_spans():
+    chunk = build_timestamp_text_chunks("ação de", ["ação de"], _SentencePiece022())[0]
+
+    assert torch.equal(chunk.token_to_unit[:4], torch.tensor([[1.0, 0.0]] * 4))
+    assert torch.equal(chunk.token_to_unit[4], torch.tensor([0.0, 0.0]))
+    assert torch.equal(chunk.token_to_unit[5:], torch.tensor([[0.0, 1.0]] * 2))
+
+
+def test_text_chunks_compare_sentencepiece_character_offsets_with_character_unit_spans():
+    chunk = build_timestamp_text_chunks("ação de", ["ação de"], _SentencePiece021())[0]
+
+    assert torch.equal(chunk.token_to_unit[:4], torch.tensor([[1.0, 0.0]] * 4))
+    assert torch.equal(chunk.token_to_unit[4], torch.tensor([0.0, 0.0]))
+    assert torch.equal(chunk.token_to_unit[5:], torch.tensor([[0.0, 1.0]] * 2))
+
+
+def test_appended_terminal_punctuation_is_marked_synthetic():
+    chunk = build_timestamp_text_chunks("hello world", ["Hello world."], _SentencePiece021())[0]
+    punctuation = [unit for unit in chunk.units if not unit.is_word]
+    assert len(punctuation) == 1
+    assert punctuation[0].synthetic
+
+    alignment = WordAlignment(chunk.units)
+    alignment.process_frame(torch.tensor([0.1, 0.9, 0.0]), True, 0.0)
+    alignment.process_frame(torch.tensor([0.1, 0.9, 0.0]), True, 0.08)
+    assert alignment.process_frame(torch.tensor([0.1, 0.9, 0.0]), False, 0.16) == [
+        WordEnd("world", 1, 0.08, 0.16)
+    ]
+
+
+def test_alignment_transitions_to_next_word_and_hard_finishes():
+    alignment = WordAlignment(_units("one", "two"))
+    first = alignment.process_frame(torch.tensor([0.8, 0.2]), voiced=True, frame_start=0.0)
+    transition = alignment.process_frame(torch.tensor([0.2, 0.8]), voiced=True, frame_start=0.08)
+    final = alignment.finish(0.16)
+
+    assert first == [WordStart("one", 0, 0.0)]
+    assert transition == [WordEnd("one", 0, 0.0, 0.08), WordStart("two", 1, 0.08)]
+    assert final == [WordEnd("two", 1, 0.08, 0.16)]
+
+
+def test_later_word_evidence_below_gate_advances_one_word():
+    alignment = WordAlignment(_units("one", "two", "three"))
+    alignment.process_frame(torch.tensor([0.9, 0.05, 0.05]), True, 0.0)
+    events = alignment.process_frame(torch.tensor([0.0009, 0.0001, 0.9]), True, 0.08)
+
+    assert events == [WordEnd("one", 0, 0.0, 0.08), WordStart("two", 1, 0.08)]
+
+
+def test_non_next_evidence_is_blocked_at_gate_threshold():
+    alignment = WordAlignment(_units("one", "two", "three"))
+    alignment.process_frame(torch.tensor([0.9, 0.05, 0.05]), True, 0.0)
+
+    assert alignment.process_frame(torch.tensor([0.001, 0.0001, 0.9]), True, 0.08) == []
+
+
+def test_non_next_evidence_uses_no_distance_margin():
+    alignment = WordAlignment(_units("one", "two", "three", "four"))
+    alignment.process_frame(torch.tensor([0.9, 0.05, 0.03, 0.02]), True, 0.0)
+    assert alignment.process_frame(torch.tensor([0.0009, 0.0001, 0.0001, 0.00091]), True, 0.08)
+
+
+def test_gate_never_blocks_next_word_evidence():
+    alignment = WordAlignment(_units("one", "two", "three"))
+    alignment.process_frame(torch.tensor([0.9, 0.05, 0.05]), True, 0.0)
+
+    assert alignment.process_frame(torch.tensor([0.5, 0.51, 0.9]), True, 0.08)
+
+
+def test_silence_closes_for_future_punctuation_but_never_opens():
+    alignment = WordAlignment(_units("one", "P:."))
+    alignment.process_frame(torch.tensor([0.8, 0.2]), True, 0.0)
+    events = alignment.process_frame(torch.tensor([0.2, 0.8]), False, 0.08)
+    assert events == [WordEnd("one", 0, 0.0, 0.08)]
+    assert alignment.process_frame(torch.tensor([0.1, 0.9]), False, 0.16) == []
+
+
+def test_unpunctuated_final_word_closes_on_first_silence():
+    alignment = WordAlignment(_units("one"))
+    alignment.process_frame(torch.tensor([1.0]), True, 0.0)
+    assert alignment.process_frame(torch.tensor([1.0]), False, 0.08) == [
+        WordEnd("one", 0, 0.0, 0.08)
+    ]
+
+
+@pytest.mark.parametrize(
+    ("amplitude", "expected"), [(0.001001, True), (0.001, False), (0.000999, False)]
+)
+def test_rms_silence_threshold_is_minus_60_dbfs(amplitude, expected):
+    assert is_voiced(torch.full((100,), amplitude)) is expected
+
+
+def test_empty_audio_is_silent():
+    assert not is_voiced(torch.empty(0))
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32, torch.float64])
+def test_silence_detection_supports_non_contiguous_float_inputs(dtype):
+    samples = torch.full((200,), 0.001001, dtype=dtype)[::2]
+    assert not samples.is_contiguous()
+    assert is_voiced(samples)
+
+
+def test_timestamp_chunk_reuses_prepared_tokens_and_keeps_manual_fallback():
+    model = object.__new__(TTSModel)
+    torch.nn.Module.__init__(model)
+    prepared_calls = []
+    model.flow_lm = SimpleNamespace(
+        device="cpu",
+        conditioner=SimpleNamespace(
+            prepare=lambda text: prepared_calls.append(text)
+            or torch.tensor([[9]], dtype=torch.long)
+        ),
+    )
+
+    retained = TimestampTextChunk(
+        "one", _units("one"), torch.ones(1, 1), torch.tensor([[3]], dtype=torch.long)
+    )
+    prepared = model._prepare_timestamp_text_chunk(retained)
+    assert prepared.tolist() == [[3]]
+    assert prepared_calls == []
+
+    manual = TimestampTextChunk("one", _units("one"), torch.ones(1, 1))
+    prepared = model._prepare_timestamp_text_chunk(manual)
+    assert prepared.tolist() == [[9]]
+    assert prepared_calls == ["one"]
+
+
+def test_closing_timestamp_generation_joins_workers_and_stops_state_mutation():
+    model = object.__new__(TTSModel)
+    torch.nn.Module.__init__(model)
+    model.flow_lm = SimpleNamespace(
+        conditioner=SimpleNamespace(prepare=lambda _text: torch.zeros((1, 1), dtype=torch.long))
+    )
+    model.mimi = SimpleNamespace(encoder_frame_rate=1, frame_rate=1)
+    model.config = SimpleNamespace(timestamp_heads=[SimpleNamespace(layer=0, head=0)])
+    model._estimate_max_gen_len = lambda _token_count: 1
+    model._flow_lm_current_end = lambda _model_state: 0
+    model_state = {"generation_steps": 0, "decoder_steps": 0}
+    threads: list[threading.Thread] = []
+
+    def decoder_worker(latents_queue, result_queue, *_args):
+        threads.append(threading.current_thread())
+        cancel_event = _args[-1]
+        while not cancel_event.is_set():
+            item = latents_queue.get()
+            if item is None:
+                return
+            model_state["decoder_steps"] += 1
+            result_queue.put(("event", AudioChunk(torch.ones(1), 0.0, 0.08)))
+
+    def generate(**kwargs):
+        cancel_event = kwargs["cancel_event"]
+        latents_queue = kwargs["latents_queue"]
+
+        def run():
+            while not cancel_event.is_set():
+                model_state["generation_steps"] += 1
+                latents_queue.put((torch.empty(0), torch.ones(1)))
+                cancel_event.wait(0.001)
+
+        thread = threading.Thread(target=run)
+        threads.append(thread)
+        thread.start()
+        return thread
+
+    model._decode_timestamped_audio_worker = decoder_worker
+    model._generate = generate
+    timestamp_chunk = TimestampTextChunk("one", _units("one"), torch.ones(1, 1))
+    generator = TTSModel._generate_audio_with_timestamps_short_text(
+        model,
+        model_state=model_state,
+        timestamp_chunk=timestamp_chunk,
+        frames_after_eos=0,
+        copy_state=False,
+        time_offset=0.0,
+    )
+
+    assert isinstance(next(generator), AudioChunk)
+    generator.close()
+    state_after_close = model_state.copy()
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert model_state == state_after_close
+
+
+def test_timestamp_decoder_passes_time_major_latent_to_mimi():
+    class RecordingMimi(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.decoded_latents = []
+
+        def quantizer(self, _latent):
+            raise AssertionError("decode_from_latent owns quantization")
+
+        def decode_from_latent(self, latent, _state):
+            self.decoded_latents.append(latent)
+            return torch.zeros(1, 1, 4)
+
+    model = object.__new__(TTSModel)
+    nn.Module.__init__(model)
+    model.mimi = RecordingMimi()
+    model.flow_lm = SimpleNamespace(emb_std=2.0, emb_mean=1.0)
+    model.config = SimpleNamespace(mimi=SimpleNamespace(sample_rate=4))
+
+    alignment = WordAlignment(_units("one"))
+    latents_queue = queue.Queue()
+    result_queue = queue.Queue()
+    latent = torch.arange(3, dtype=torch.float32).view(1, 1, 3)
+    latents_queue.put((latent, torch.ones(1)))
+    latents_queue.put(None)
+
+    with patch("pocket_tts.models.tts_model.is_voiced", return_value=True):
+        model._decode_timestamped_audio_worker(
+            latents_queue,
+            result_queue,
+            mimi_sequence_length=2,
+            mimi_steps_per_latent=1,
+            alignment=alignment,
+            time_offset=0.0,
+            cancel_event=threading.Event(),
+        )
+
+    assert len(model.mimi.decoded_latents) == 1
+    torch.testing.assert_close(model.mimi.decoded_latents[0], latent * 2.0 + 1.0)
+    assert model.mimi.decoded_latents[0].shape == (1, 1, 3)
+    results = list(result_queue.queue)
+    assert any(kind == "event" and isinstance(value, AudioChunk) for kind, value in results)
+    assert results[-1] == ("done", 1.0)
+
+
+def test_selected_attention_matches_manual_text_softmax_and_preserves_output():
+    torch.manual_seed(0)
+    attention = StreamingMultiheadAttention(
+        embed_dim=8, num_heads=2, rope=RotaryEmbedding(max_period=10_000)
+    )
+    attention._module_absolute_name = "attention"
+    state = {"attention": attention.init_state(batch_size=1, sequence_length=8)}
+    prompt = torch.randn(1, 2, 8)
+    with torch.no_grad():
+        attention(prompt, state)
+    attention.increment_step(state["attention"], increment=2)
+
+    query = torch.randn(1, 1, 8)
+    captured_state = copy.deepcopy(state)
+    baseline_state = copy.deepcopy(state)
+    capture = SelectedAttentionCapture([(0, 1)], 0, 2, torch.eye(2))
+    capture.begin_frame()
+    captured_output = attention(query, captured_state, attention_capture=capture, layer_index=0)
+    scores = capture.finish_frame()
+    baseline_output = attention(query, baseline_state)
+
+    projected = attention.in_proj(query).view(1, 1, 3, 2, 4)
+    q, _, _ = torch.unbind(projected, dim=2)
+    cached_k = state["attention"]["cache"][0, :, :2].permute(0, 2, 1, 3)
+    q, _ = attention.rope(q, q, offset=state["attention"]["offset"].view(-1)[0])
+    logits = torch.einsum("bd,btd->bt", q[:, 0, 1], cached_k[:, 1])
+    expected = torch.softmax(logits / 2.0, dim=-1)[0]
+
+    torch.testing.assert_close(scores, expected)
+    torch.testing.assert_close(captured_output, baseline_output)
+
+
+def test_selected_attention_supports_multiple_heads_in_one_layer():
+    torch.manual_seed(1)
+    attention = StreamingMultiheadAttention(
+        embed_dim=8, num_heads=2, rope=RotaryEmbedding(max_period=10_000)
+    )
+    attention._module_absolute_name = "attention"
+    state = {"attention": attention.init_state(batch_size=1, sequence_length=8)}
+    prompt = torch.randn(1, 2, 8)
+    with torch.no_grad():
+        attention(prompt, state)
+    attention.increment_step(state["attention"], increment=2)
+
+    query = torch.randn(1, 1, 8)
+    captured_state = copy.deepcopy(state)
+    capture = SelectedAttentionCapture([(0, 0), (0, 1)], 0, 2, torch.eye(2))
+    capture.begin_frame()
+    attention(query, captured_state, attention_capture=capture, layer_index=0)
+    scores = capture.finish_frame()
+
+    projected = attention.in_proj(query).view(1, 1, 3, 2, 4)
+    q, _, _ = torch.unbind(projected, dim=2)
+    cached_k = state["attention"]["cache"][0, :, :2].permute(0, 2, 1, 3)
+    q, _ = attention.rope(q, q, offset=state["attention"]["offset"].view(-1)[0])
+    logits = torch.einsum("bhd,bhtd->bht", q[:, 0], cached_k)
+    expected = torch.softmax(logits / 2.0, dim=-1).mean(dim=1)[0]
+    torch.testing.assert_close(scores, expected)
+
+
+def test_token_aggregation_normalizes_each_head_then_averages_equally():
+    capture = SelectedAttentionCapture(
+        [(0, 0), (1, 1)], 0, 3, torch.tensor([[1.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+    )
+    capture.begin_frame()
+    capture.record(0, (0,), torch.tensor([[[0.25, 0.25, 0.5]]]))
+    capture.record(1, (1,), torch.tensor([[[0.1, 0.2, 0.7]]]))
+    torch.testing.assert_close(capture.finish_frame(), torch.tensor([0.4, 0.6]))
+
+
+def test_selected_attention_supports_dynamic_int8_projections():
+    attention = StreamingMultiheadAttention(
+        embed_dim=8, num_heads=2, rope=RotaryEmbedding(max_period=10_000)
+    ).eval()
+    with pytest.warns(DeprecationWarning):
+        attention = torch.ao.quantization.quantize_dynamic(
+            attention, {torch.nn.Linear}, dtype=torch.qint8
+        )
+    attention._module_absolute_name = "attention"
+    state = {"attention": attention.init_state(batch_size=1, sequence_length=4)}
+    capture = SelectedAttentionCapture([(0, 0)], 0, 1, torch.ones(1, 1))
+    with torch.no_grad():
+        attention(torch.randn(1, 1, 8), state)
+        attention.increment_step(state["attention"])
+        capture.begin_frame()
+        output = attention(torch.randn(1, 1, 8), state, attention_capture=capture, layer_index=0)
+    assert output.shape == (1, 1, 8)
+    torch.testing.assert_close(capture.finish_frame(), torch.ones(1))
+
+
+def test_timestamped_non_streaming_audio_concatenates_audio_events():
+    model = object.__new__(TTSModel)
+    torch.nn.Module.__init__(model)
+
+    def fake_stream(**_kwargs):
+        def events():
+            yield WordStart("one", 0, 0.0)
+            yield AudioChunk(torch.tensor([1.0, 2.0]), 0.0, 0.08)
+            yield WordEnd("one", 0, 0.0, 0.16)
+            yield AudioChunk(torch.tensor([3.0]), 0.08, 0.16)
+
+        return events()
+
+    model.generate_audio_with_timestamps_stream = fake_stream
+    result = TTSModel.generate_audio_with_timestamps(model, {}, "one")
+    assert isinstance(result, TimestampedAudio)
+    torch.testing.assert_close(result.audio, torch.tensor([1.0, 2.0, 3.0]))
+    assert result.words == (WordTimestamp("one", 0, 0.0, 0.16),)
+
+
+def test_unsupported_config_fails_before_generation():
+    model = object.__new__(TTSModel)
+    torch.nn.Module.__init__(model)
+    model.config = SimpleNamespace(timestamp_heads=None)
+    with pytest.raises(ValueError, match="timestamp_heads is absent"):
+        model.generate_audio_with_timestamps_stream({}, "one")
+
+
+def test_chunk_event_offsets_and_global_word_indices():
+    model = object.__new__(TTSModel)
+    torch.nn.Module.__init__(model)
+    model.model_recommended_frames_after_eos = None
+    model.pad_with_spaces_for_short_inputs = False
+    model.remove_semicolons = False
+    model.flow_lm = SimpleNamespace(
+        conditioner=SimpleNamespace(tokenizer=SimpleNamespace(sp=object()))
+    )
+    chunks = [
+        TimestampTextChunk("One.", _units("One", "P:."), torch.empty(0, 2)),
+        TimestampTextChunk(
+            "Two.",
+            (_TextUnit("Two", 0, 3, _SourceWord("Two", 1, 5, 8)), _TextUnit(".", 3, 4, None)),
+            torch.empty(0, 2),
+        ),
+    ]
+
+    def short_text(**kwargs):
+        timestamp_chunk = kwargs["timestamp_chunk"]
+        time_offset = kwargs["time_offset"]
+        word = timestamp_chunk.words[0]
+        yield WordStart(word.text, word.word_index, time_offset)
+        yield AudioChunk(torch.ones(2), time_offset, time_offset + 0.08)
+        return time_offset + 0.08
+
+    model._generate_audio_with_timestamps_short_text = short_text
+    with (
+        patch(
+            "pocket_tts.models.tts_model.split_into_best_sentences", return_value=["One.", "Two."]
+        ),
+        patch("pocket_tts.models.tts_model._iter_timestamp_text_chunks", return_value=iter(chunks)),
+    ):
+        generator = TTSModel._generate_audio_with_timestamps_events(
+            model, {}, "One. Two.", max_tokens=50, frames_after_eos=None, copy_state=True
+        )
+        events = list(generator)
+
+    assert [event.word_index for event in events if isinstance(event, WordStart)] == [0, 1]
+    audio_events = [event for event in events if isinstance(event, AudioChunk)]
+    assert [(event.start_time, event.end_time) for event in audio_events] == [
+        (0.0, 0.08),
+        (0.08, 0.16),
+    ]
+    assert audio_events[-1].end_time == 0.16
+
+
+def test_degraded_word_gaps_preserve_audio_and_event_order():
+    model = object.__new__(TTSModel)
+    torch.nn.Module.__init__(model)
+    model.model_recommended_frames_after_eos = None
+    model.pad_with_spaces_for_short_inputs = False
+    model.remove_semicolons = False
+    model.flow_lm = SimpleNamespace(
+        conditioner=SimpleNamespace(tokenizer=SimpleNamespace(sp=object()))
+    )
+    chunk = TimestampTextChunk(
+        "One different three.",
+        (
+            _TextUnit("One", 0, 3, _SourceWord("one", 0, 0, 3)),
+            _TextUnit("different", 4, 13, None, synthetic=True),
+            _TextUnit("three", 14, 19, _SourceWord("three", 2, 12, 17)),
+            _TextUnit(".", 19, 20, None),
+        ),
+        torch.ones(1, 4),
+    )
+
+    def short_text(**kwargs):
+        timestamp_chunk = kwargs["timestamp_chunk"]
+        time_offset = kwargs["time_offset"]
+        for word in timestamp_chunk.words:
+            yield WordStart(word.text, word.word_index, time_offset)
+        yield AudioChunk(torch.tensor([1.0, 2.0]), time_offset, time_offset + 0.08)
+        return time_offset + 0.08
+
+    model._generate_audio_with_timestamps_short_text = short_text
+    with (
+        patch("pocket_tts.models.tts_model.split_into_best_sentences", return_value=[chunk.text]),
+        patch(
+            "pocket_tts.models.tts_model._iter_timestamp_text_chunks", return_value=iter([chunk])
+        ),
+    ):
+        events = list(
+            TTSModel._generate_audio_with_timestamps_events(
+                model, {}, "one missing three", 50, None, True
+            )
+        )
+
+    word_events = [event for event in events if isinstance(event, WordStart)]
+    audio_index = next(index for index, event in enumerate(events) if isinstance(event, AudioChunk))
+    assert [event.word_index for event in word_events] == [0, 2]
+    assert all(events.index(event) < audio_index for event in word_events)
+    torch.testing.assert_close(events[audio_index].audio, torch.tensor([1.0, 2.0]))
+
+
+def test_timestamp_head_config_validation():
+    config = load_config(CONFIGS_DIR / "english.yaml").model_dump()
+    config["timestamp_heads"] = [{"layer": 3, "head": 8}]
+    validated = Config(**config)
+    assert validated.timestamp_heads[0].layer == 3
+
+    config["timestamp_heads"] = [{"layer": 6, "head": 0}]
+    with pytest.raises(ValueError, match="outside the FlowLM layer range"):
+        Config(**config)
+
+    config["timestamp_heads"] = [{"layer": 0, "head": 16}]
+    with pytest.raises(ValueError, match="outside the FlowLM head range"):
+        Config(**config)
+
+    config["timestamp_heads"] = [{"layer": 0, "head": 0}, {"layer": 0, "head": 0}]
+    with pytest.raises(ValueError, match="Duplicate timestamp head"):
+        Config(**config)
+
+
+@pytest.fixture(scope="module")
+def spanish_timestamp_tokenizer():
+    config = load_config(CONFIGS_DIR / "spanish.yaml")
+    tokenizer_path = download_if_necessary(config.flow_lm.lookup_table.tokenizer_path)
+    return sentencepiece.SentencePieceProcessor(str(tokenizer_path))
+
+
+@pytest.fixture(scope="module")
+def spanish_timestamp_model():
+    return TTSModel.load_model(language="spanish")
+
+
+@pytest.fixture(scope="module")
+def spanish_timestamp_model_and_voice_state(spanish_timestamp_model):
+    model = spanish_timestamp_model
+    sample_positions = torch.arange(model.sample_rate, dtype=torch.float32)
+    audio_prompt = (0.1 * torch.sin(2 * torch.pi * 220 * sample_positions / model.sample_rate))[
+        None
+    ]
+    voice_state = model.get_state_for_audio_prompt(audio_prompt)
+    return model, voice_state
+
+
+@pytest.mark.parametrize(
+    ("source_text", "expected_text", "expected_words"),
+    [
+        ("A ﬁne result.", "A fine result.", ("A", "ﬁne", "result")),
+        (unicodedata.normalize("NFD", "Café naïve."), "Café naïve.", ("Cafe\u0301", "nai\u0308ve")),
+    ],
+)
+def test_timestamp_chunks_use_production_tokenizer_for_canonical_unicode(
+    spanish_timestamp_tokenizer, source_text, expected_text, expected_words
+):
+    chunk = build_timestamp_text_chunks(source_text, [source_text], spanish_timestamp_tokenizer)[0]
+    expected_token_ids = spanish_timestamp_tokenizer.encode(chunk.text, out_type=int)
+
+    assert chunk.text == expected_text
+    assert chunk.token_to_unit.shape[0] == len(expected_token_ids)
+    assert chunk.prepared_tokens is not None
+    assert chunk.prepared_tokens[0].tolist() == expected_token_ids
+    assert [word.text for word in chunk.words] == list(expected_words)
+
+
+def test_timestamp_generation_end_to_end_with_accented_text(
+    spanish_timestamp_model_and_voice_state,
+):
+    model, voice_state = spanish_timestamp_model_and_voice_state
+    stream = model.generate_audio_with_timestamps_stream(
+        voice_state, "El café está aquí.", frames_after_eos=0
+    )
+    events = list(stream)
+
+    word_events = [event for event in events if isinstance(event, WordEnd)]
+    expected_words = ["El", "café", "está", "aquí"]
+    observed_words = [(event.word_index, event.word) for event in word_events]
+    assert observed_words
+    assert observed_words == list(enumerate(expected_words))[: len(observed_words)]
+    audio_events = [event for event in events if isinstance(event, AudioChunk)]
+    assert audio_events
+    assert all(event.end_time > event.start_time for event in audio_events)


### PR DESCRIPTION
Closes #66 

Adds timestamped methods for both streaming and non-streaming generation.
We use the attention patterns of attention heads that align closely with word boundaries.
Example from the 6L English checkpoint (top: token-level attention pattern. bottom: word-aggregated attention patterns, reference and predicted alignment):
<img width="1604" height="957" alt="image" src="https://github.com/user-attachments/assets/9e0ad212-0fde-45fc-8264-79c4bfd75d5f" />

## Explanation
The heads chosen all have fairly similar behaviour, they attend to the word that's currently being spoken, or, if no word is currently being spoken, they attend to the next word that will be spoken.
We use a silence detector to differentiate between those two cases, everything tested worked about equally well, but I ended up settling on RMS -60db.
We start at the first word, we close a word when the next word has higher aggregated attention than itself. We start the next word on its first non-silent frame.
There's special behaviour for the last word, since it doesn't have a later word to attend to, we close it on finding a silent frame.
If the current word has less than a certain threshold of attention (currently 1e-3), it may trigger a transition if any later word has higher attention than itself. This is meant to deal with cases where a word is skipped because it never had more attention than the current word (mainly happens with very short words). In these cases, we could become stuck on a previous word and be unable to transition further.

I tested the following transition methods as well, but found this one to work best:
- Transition to the word with the highest attention
- Transition to the next word when any future word has higher attention

They both have a similar problem, in long sentences, they are very likely to be thrown off by noise in the attention patterns.

## Accuracy
Accuracy of every head, measured as MAE against crisperwhisper 2.0 small's timestamps:
| Checkpoint          | Head        | Samples | Words | Skip rate | MAE           |
|---------------------|-------------|---------|-------|-----------|---------------|
| English 2026-04     | L3H8        | 552     | 3,841 | 0.0260%   | 44.52 ms      |
| English 2026-04 24L | L14H10      | 204     | 1,874 | 0.0000%   | 46.77 ms      |
| English 2026-01     | L3H8        | 120     | 990   | 0.0000%   | 72.90 ms      |
| French 24L          | L11H9+L17H8 | 81      | 628   | 0.0000%   | 59.62 ms      |
| German              | L3H6        | 57      | 465   | 0.0000%   | 57.48 ms      |
| German 24L          | L3H6+L16H6  | 39      | 354   | 0.2825%   | 67.20 ms      |
| Italian             | L4H0        | 46      | 388   | 0.0000%   | 66.98 ms      |
| Italian 24L         | L4H0+L15H12 | 56      | 491   | 0.0000%   | 117.60 ms     |
| Portuguese          | L3H14       | 57      | 533   | 0.0000%   | 68.56 ms      |
| Portuguese 24L      | L3H14+L15H9 | 62      | 597   | 0.0000%   | 120.62 ms     |
| Spanish             | L2H3        | 55      | 507   | 0.0000%   | 91.58 ms      |
| Spanish 24L         | L6H9        | 61      | 570   | 0.0000%   | 78.25 ms      |

## Limitations
We use the same algorithm for streaming and non-streaming generation, this means we don't make use of future information for predicting timestamps.
Therefore, It'd be possible to substantially improve accuracy of non-streaming timestamps by using something like Dynamic Time Warping.
Timestamped generation adds 0.8ms of overhead to the first frame and 0.2ms to subsequent ones, as measured on my machine (i5-12400F)