### PR TITLE
Peek at the latents manifest instead of reading it whole

### DIFF
--- a/training/train_utils.py
+++ b/training/train_utils.py
@@ -169,8 +169,11 @@ def ensure_train_latents(args: TrainArgs, mimi, device, rank: int, world_size: i
         if json.loads(meta_path.read_text()).get("mimi_hash") != current:
             return False
         # A manifest from an older layout (no latents_file field) would send
-        # rows down the audio path and crash the latent collate.
-        first = latents_manifest.read_text().split("\n", 1)[0]
+        # rows down the audio path and crash the latent collate. Read only the
+        # first line: read_text() would materialize the whole manifest (tens
+        # of GB for large corpora) in every rank at once.
+        with latents_manifest.open() as f:
+            first = f.readline()
         return "latents_file" in json.loads(first)
 
     if not is_fresh():


### PR DESCRIPTION
`ensure_train_latents`'s freshness check did `latents_manifest.read_text().split("\n", 1)[0]` to inspect the first row — materializing the entire manifest as a Python string (plus a second copy from the split) in every rank simultaneously. On a full-corpus manifest (11.3M rows, ~20 GB) that's on the order of 160 GB of transient allocations for a 4-rank job at startup, which OOM-killed training runs. Reading a single line does the same check in constant memory.

Observed in practice: 4-GPU jobs on a 20 GB latents manifest OOM-killed at 250-375 GB host RAM limits during startup; fixed by this change (plus fewer loader procs) they run at a fraction of that.