### PR TITLE
Dataloader: lazy manifest access via a cached offset index

### DIFF
--- a/training/dataloader.py
+++ b/training/dataloader.py
@@ -9,6 +9,7 @@ ranks by line index.
 import json
 import logging
 import multiprocessing.queues
+import os
 import queue
 import random
 import threading
@@ -53,16 +54,76 @@ class Batch:
     prompt_latents: torch.Tensor | None = None
 
 
-def load_entries(path: str, rank: int, world_size: int) -> list[str]:
-    entries = []
-    with Path(path).open() as f:
-        for idx, line in enumerate(f):
-            if idx % world_size != rank:
-                continue
-            # We parse lazily, 6x less memory
-            entries.append(line)
-    logger.info(f"loaded {len(entries)} entries from {path} (rank {rank}/{world_size})")
-    assert entries, f"no entries for rank {rank} in {path}"
+class LazyEntries:
+    """This rank's stride of manifest lines, read on demand via an offset index.
+
+    Large manifests (tens of GB) would otherwise be held as per-process string
+    lists by every loader subprocess. The index is a uint64 array of line-start
+    offsets cached next to the manifest; the lines themselves stay on disk and
+    are served through the (shared, reclaimable) page cache.
+    """
+
+    def __init__(self, path: str, rank: int, world_size: int) -> None:
+        self._path = Path(path)
+        self._rank = rank
+        self._world = world_size
+        self._offsets = None
+        self._file = None
+        self._ensure_index()
+
+    def _index_path(self) -> Path:
+        return self._path.with_name(self._path.name + ".idx")
+
+    def _ensure_index(self) -> None:
+        idx = self._index_path()
+        src = self._path.stat()
+        if idx.exists():
+            meta = idx.stat()
+            if meta.st_mtime >= src.st_mtime and meta.st_size > 8:
+                return
+        offsets = [0]
+        with self._path.open("rb") as f:
+            for line in f:
+                offsets.append(offsets[-1] + len(line))
+        arr = np.asarray(offsets, dtype=np.uint64)
+        tmp = idx.with_name(idx.name + f".tmp.{os.getpid()}")
+        arr.tofile(tmp)
+        os.replace(tmp, idx)  # concurrent builders write identical content
+        logger.info(f"indexed {len(arr) - 1} lines of {self._path.name}")
+
+    def _load(self) -> None:
+        all_offsets = np.fromfile(self._index_path(), dtype=np.uint64)
+        starts, ends = all_offsets[:-1], all_offsets[1:]
+        self._starts = starts[self._rank :: self._world]
+        self._ends = ends[self._rank :: self._world]
+        self._offsets = True
+
+    def __len__(self) -> int:
+        if self._offsets is None:
+            self._load()
+        return len(self._starts)
+
+    def __getitem__(self, i: int) -> str:
+        if self._offsets is None:
+            self._load()
+        if self._file is None:
+            self._file = self._path.open("rb")
+        self._file.seek(int(self._starts[i]))
+        return self._file.read(int(self._ends[i] - self._starts[i])).decode()
+
+    def __getstate__(self) -> dict[str, object]:
+        return {"_path": self._path, "_rank": self._rank, "_world": self._world}
+
+    def __setstate__(self, state: dict[str, object]) -> None:
+        self.__dict__.update(state)
+        self._offsets = None
+        self._file = None
+
+
+def load_entries(path: str, rank: int, world_size: int) -> LazyEntries:
+    entries = LazyEntries(path, rank, world_size)
+    logger.info(f"indexed {len(entries)} entries from {path} (rank {rank}/{world_size})")
+    assert len(entries), f"no entries for rank {rank} in {path}"
     return entries
 
 


### PR DESCRIPTION
On large corpora the manifest jsonl reaches tens of GB (per-word alignments), and every spawned loader subprocess held its stride of lines as Python strings — gigabytes of heap per process, multiplied by ranks x loader procs, with long-run heap churn ending in host-RAM OOM kills.

`LazyEntries` replaces the string lists: a uint64 line-offset index is built once (atomic tmp+rename, mtime-invalidated, ~8 bytes/line — 90 MB for an 11M-row manifest) and cached next to the manifest; lines are read on demand through the shared page cache. Interface stays `len()` + `[i] -> str`, so the loader is unchanged; the object pickles cheaply to spawn workers (offsets reload lazily in the child).

Verified: unit tests for stride equivalence, spawn pickling, index reuse and stale-index invalidation; full repo suite passes; a live training run on precomputed latents trains normally with the index in place.