### PR TITLE
Reseed the dataloader with the resume step

### DIFF
--- a/training/train.py
+++ b/training/train.py
@@ -183,7 +183,10 @@ def main(config_path: str):
             args.data.max_voice_prompt_sec,
             rank,
             run.world_size,
-            seed=args.seed,
+            # Fold the resume step into the seed: the loader keeps no state
+            # across restarts, so a fixed seed would replay the same
+            # permutation from the top and bias coverage toward its head.
+            seed=args.seed + start_step,
             shuffle=args.data.shuffle,
             num_procs=args.data.loader_procs,
         )


### PR DESCRIPTION
The dataloader keeps no state across restarts, and its rng seed is fixed — so every relaunch replays the same shuffle permutation from position zero while the model resumes at step N. On short-epoch datasets that's harmless; on a full-length corpus (~176k steps/epoch at batch 64) a run with a couple of restarts oversamples the head of one permutation and can leave the tail unseen.

Folding `start_step` into the seed gives each restart a fresh permutation: not positionally exact, but unbiased coverage, which is what matters statistically.

https://claude.ai/code/session_01Rp7ArRpP2w3WVZyFbjFvuo