### PR TITLE
Add Hindi community model and configurable terminal punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,9 @@ uvx pocket-tts generate --config hf://vvolhejn/pocket-tts-czech/czech.yaml@7b776
 
 - [Pocket TTS Hindi](https://huggingface.co/saryps-labs/pocket-tts-hindi) by [Saryps Labs](https://huggingface.co/saryps-labs) (community research release):
 ```bash
-uvx pocket-tts generate --config hf://saryps-labs/pocket-tts-hindi/config.yaml@dbaa326069d20bfbdaeb625613736773741a24ea
+uvx pocket-tts generate \
+  --config hf://saryps-labs/pocket-tts-hindi/config.yaml@dbaa326069d20bfbdaeb625613736773741a24ea \
+  --text "आज का दिन बहुत अच्छा है"
 ```
 
 Want your model here? Head to the [training Readme](https://github.com/kyutai-labs/pocket-tts/blob/main/training/README.md) to get started!

--- a/README.md
+++ b/README.md
@@ -295,6 +295,11 @@ uvx pocket-tts generate --config hf://user/repo/config_file.yaml@commit_hash
 uvx pocket-tts generate --config hf://vvolhejn/pocket-tts-czech/czech.yaml@7b7760dd0fe994a0800f2fdbc837dc4b8f219d1c
 ```
 
+- [Pocket TTS Hindi](https://huggingface.co/saryps-labs/pocket-tts-hindi) by [Saryps Labs](https://huggingface.co/saryps-labs) (community research release):
+```bash
+uvx pocket-tts generate --config hf://saryps-labs/pocket-tts-hindi/config.yaml@dbaa326069d20bfbdaeb625613736773741a24ea
+```
+
 Want your model here? Head to the [training Readme](https://github.com/kyutai-labs/pocket-tts/blob/main/training/README.md) to get started!
 
 ## Projects using Pocket TTS

--- a/pocket_tts/models/text_chunking.py
+++ b/pocket_tts/models/text_chunking.py
@@ -12,7 +12,10 @@ logger = logging.getLogger(__name__)
 
 
 def prepare_text_prompt(
-    text: str, pad_with_spaces_for_short_inputs: bool, remove_semicolons: bool
+    text: str,
+    pad_with_spaces_for_short_inputs: bool,
+    remove_semicolons: bool,
+    append_terminal_punctuation: bool = True,
 ) -> tuple[str, int]:
     text = text.strip()
     if text == "":
@@ -32,7 +35,7 @@ def prepare_text_prompt(
 
     # Let's make sure it ends with some kind of punctuation
     # If it ends with a letter or digit, we add a period.
-    if text[-1].isalnum():
+    if append_terminal_punctuation and text[-1].isalnum():
         text = text + "."
 
     # The model does not perform well when there are very few tokens, so
@@ -110,9 +113,13 @@ def split_into_best_sentences(
     max_tokens: int,
     pad_with_spaces_for_short_inputs: bool,
     remove_semicolons: bool,
+    append_terminal_punctuation: bool = True,
 ) -> list[str]:
     text_to_generate, _ = prepare_text_prompt(
-        text_to_generate, pad_with_spaces_for_short_inputs, remove_semicolons
+        text_to_generate,
+        pad_with_spaces_for_short_inputs,
+        remove_semicolons,
+        append_terminal_punctuation,
     )
     text_to_generate = text_to_generate.strip()
     tokens = tokenizer(text_to_generate)

--- a/pocket_tts/models/tts_model.py
+++ b/pocket_tts/models/tts_model.py
@@ -97,6 +97,7 @@ class TTSModel(nn.Module):
         pad_with_spaces_for_short_inputs: bool = False,
         model_recommended_frames_after_eos: int | None = None,
         remove_semicolons: bool = False,
+        append_terminal_punctuation: bool = True,
     ):
         super().__init__()
         self.flow_lm = flow_lm
@@ -110,6 +111,7 @@ class TTSModel(nn.Module):
         self.pad_with_spaces_for_short_inputs: bool = pad_with_spaces_for_short_inputs
         self.model_recommended_frames_after_eos = model_recommended_frames_after_eos
         self.remove_semicolons = remove_semicolons
+        self.append_terminal_punctuation = append_terminal_punctuation
 
     @property
     def device(self) -> torch.device:
@@ -145,6 +147,7 @@ class TTSModel(nn.Module):
             pad_with_spaces_for_short_inputs=config.pad_with_spaces_for_short_inputs,
             model_recommended_frames_after_eos=config.model_recommended_frames_after_eos,
             remove_semicolons=config.remove_semicolons,
+            append_terminal_punctuation=config.append_terminal_punctuation,
         )
         return tts_model
 
@@ -670,11 +673,15 @@ class TTSModel(nn.Module):
             max_tokens,
             self.pad_with_spaces_for_short_inputs,
             remove_semicolons=self.remove_semicolons,
+            append_terminal_punctuation=self.append_terminal_punctuation,
         )
 
         for chunk in chunks:
             text_to_generate, frames_after_eos_guess = prepare_text_prompt(
-                chunk, self.pad_with_spaces_for_short_inputs, self.remove_semicolons
+                chunk,
+                self.pad_with_spaces_for_short_inputs,
+                self.remove_semicolons,
+                self.append_terminal_punctuation,
             )
             frames_after_eos_guess += 2
             effective_frames = (

--- a/pocket_tts/utils/config.py
+++ b/pocket_tts/utils/config.py
@@ -120,6 +120,7 @@ class Config(StrictModel):
     weights_path_without_voice_cloning: str | None = None
     pad_with_spaces_for_short_inputs: bool = False
     remove_semicolons: bool = False
+    append_terminal_punctuation: bool = True
     model_recommended_frames_after_eos: int | None = None
     default_temperature: float = 0.7
 

--- a/tests/test_generation_regressions.py
+++ b/tests/test_generation_regressions.py
@@ -20,9 +20,11 @@ def test_generate_audio_stream_uses_prepared_chunk_text(monkeypatch: pytest.Monk
         max_tokens: int,
         pad_with_spaces_for_short_inputs: bool,
         remove_semicolons: bool,
+        append_terminal_punctuation: bool,
     ) -> list[str]:
         assert text_to_generate == "hi"
         assert pad_with_spaces_for_short_inputs is True
+        assert append_terminal_punctuation is True
         return ["hi"]
 
     def fake_generate_audio_stream_short_text(**kwargs: object) -> Iterator[torch.Tensor]:
@@ -39,6 +41,7 @@ def test_generate_audio_stream_uses_prepared_chunk_text(monkeypatch: pytest.Monk
             model_recommended_frames_after_eos=None,
             pad_with_spaces_for_short_inputs=True,
             remove_semicolons=False,
+            append_terminal_punctuation=True,
             _generate_audio_stream_short_text=fake_generate_audio_stream_short_text,
         ),
     )

--- a/tests/test_split_sentences.py
+++ b/tests/test_split_sentences.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from pocket_tts.models.tts_model import split_into_best_sentences
+from pocket_tts.models.tts_model import prepare_text_prompt, split_into_best_sentences
 from pocket_tts.modules.text_conditioner import SentencePieceTokenizer, get_default_tokenizer
 
 
@@ -126,6 +126,16 @@ def test_empty_string_raises(tokenizer: SentencePieceTokenizer):
         split_into_best_sentences(
             tokenizer, "", 50, pad_with_spaces_for_short_inputs=False, remove_semicolons=False
         )
+
+
+def test_terminal_punctuation_can_be_disabled_for_punctuation_free_training():
+    text, _ = prepare_text_prompt(
+        "नमस्ते आज आपका दिन कैसा रहा",
+        pad_with_spaces_for_short_inputs=False,
+        remove_semicolons=False,
+        append_terminal_punctuation=False,
+    )
+    assert text == "नमस्ते आज आपका दिन कैसा रहा"
 
 
 def test_decimals_are_not_split_on_period(tokenizer: SentencePieceTokenizer):


### PR DESCRIPTION
## Summary

Adds the [Saryps Labs Hindi Pocket TTS](https://huggingface.co/saryps-labs/pocket-tts-hindi) research release to the community-trained models list.

The model is a 109.5M-parameter, six-layer depth-distilled Hindi model supporting streaming synthesis and prompt-based voice cloning.

Closes the announcement context in #281.

## Runtime compatibility

The Hindi tokenizer and training corpus contain essentially no punctuation. Pocket TTS currently appends a period to text ending in an alphanumeric character, but that period maps to `<unk>` for this tokenizer and can cause unstable duration or premature EOS.

This PR adds the config option:

```yaml
append_terminal_punctuation: false