### PR TITLE
README: Czech example with a Czech sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,9 @@ uvx pocket-tts generate --config hf://user/repo/config_file.yaml@commit_hash
 
 - [pocket-tts-czech](https://huggingface.co/vvolhejn/pocket-tts-czech) by @vvolhejn (trained internally at Kyutai):
 ```bash
-uvx pocket-tts generate --config hf://vvolhejn/pocket-tts-czech/czech.yaml@7b7760dd0fe994a0800f2fdbc837dc4b8f219d1c
+uvx pocket-tts generate \
+  --config hf://vvolhejn/pocket-tts-czech/czech.yaml@7b7760dd0fe994a0800f2fdbc837dc4b8f219d1c \
+  --text "Dnešek je velmi dobrý den"
 ```
 
 - [Pocket TTS Hindi](https://huggingface.co/saryps-labs/pocket-tts-hindi) by [Saryps Labs](https://huggingface.co/saryps-labs) (community research release):


### PR DESCRIPTION
The Czech community-model example ran with the default English text; it now passes a Czech sentence with `--text`, matching the Hindi example.