### PR TITLE
Add Indonesian 24L community model to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,13 @@ uvx pocket-tts generate \
   --text "안녕하세요. 한국어 음성 합성 모델입니다."
 ```
 
+- [Pocket TTS Indonesian 24L](https://huggingface.co/anak10thn/pocket-tts-indonesian) by [@anak10thn](https://huggingface.co/anak10thn) (community research release):
+```bash
+uvx pocket-tts generate \
+  --config hf://anak10thn/pocket-tts-indonesian/config.yaml@6160f98e7a6e71e3aa3e063e582d7827518c632f \
+  --text "Selamat pagi. Ini model sintesis suara bahasa Indonesia."
+```
+
 Want your model here? Head to the [training Readme](https://github.com/kyutai-labs/pocket-tts/blob/main/training/README.md) to get started!
 
 ## Projects using Pocket TTS

--- a/README.md
+++ b/README.md
@@ -312,10 +312,11 @@ uvx pocket-tts generate \
   --text "안녕하세요. 한국어 음성 합성 모델입니다."
 ```
 
-- [Pocket TTS Indonesian 24L](https://huggingface.co/anak10thn/pocket-tts-indonesian) by [@anak10thn](https://huggingface.co/anak10thn) (community research release):
+- [Pocket TTS Indonesian](https://huggingface.co/anak10thn/pocket-tts-indonesian) by [@anak10thn](https://huggingface.co/anak10thn) (community research release), 6 layers, distilled with guidance baked in:
 ```bash
 uvx pocket-tts generate \
-  --config hf://anak10thn/pocket-tts-indonesian/config.yaml@6160f98e7a6e71e3aa3e063e582d7827518c632f \
+  --config hf://anak10thn/pocket-tts-indonesian/indonesian_6l.yaml@f44e4fc2b2fd79918667a1264e34505ea39f04fa \
+  --eos-threshold -6.0 \
   --text "Selamat pagi. Ini model sintesis suara bahasa Indonesia."
 ```
 

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ uvx pocket-tts generate \
   --text "안녕하세요. 한국어 음성 합성 모델입니다."
 ```
 
-- [Pocket TTS Indonesian](https://huggingface.co/anak10thn/pocket-tts-indonesian) by [@anak10thn](https://huggingface.co/anak10thn) (community research release), 6 layers, distilled with guidance baked in:
+- [Pocket TTS Indonesian](https://huggingface.co/anak10thn/pocket-tts-indonesian) by [@anak10thn](https://huggingface.co/anak10thn) (community research release), 6 layers:
 ```bash
 uvx pocket-tts generate \
   --config hf://anak10thn/pocket-tts-indonesian/indonesian_6l.yaml@635cde7a28301861b120f57ec4dda8525073017c \

--- a/README.md
+++ b/README.md
@@ -315,8 +315,8 @@ uvx pocket-tts generate \
 - [Pocket TTS Indonesian](https://huggingface.co/anak10thn/pocket-tts-indonesian) by [@anak10thn](https://huggingface.co/anak10thn) (community research release), 6 layers, distilled with guidance baked in:
 ```bash
 uvx pocket-tts generate \
-  --config hf://anak10thn/pocket-tts-indonesian/indonesian_6l.yaml@f44e4fc2b2fd79918667a1264e34505ea39f04fa \
-  --eos-threshold -6.0 \
+  --config hf://anak10thn/pocket-tts-indonesian/indonesian_6l.yaml@635cde7a28301861b120f57ec4dda8525073017c \
+  --eos-threshold -5.0 \
   --text "Selamat pagi. Ini model sintesis suara bahasa Indonesia."
 ```
 


### PR DESCRIPTION
## Summary

- Add the community-trained Indonesian 24-layer Pocket TTS model to the README
- Pinned Hugging Face config with an Indonesian generation example
- Documents only the 24-layer teacher

Replaces #293, which carried the training code as well — following the guidance
there to keep this to a README entry, in the shape of #291. The pipeline lives
on my fork and is linked from the model card rather than merged here:
https://github.com/anak10thn/pocket-tts/tree/indonesian

## The model

A 24-layer teacher finetuned from `english_2026-04_24l` with a fresh Indonesian
tokenizer, on 502 h of LEMAS Indonesian speech. Scored on 153 cross-sentence
pairs over 116 held-out speakers (Whisper-large-v3, language-agnostic
normalizer, `--temp 0.3 --cfg 2.0 --n-steps 1`):

| | value |
|---|---|
| speaker similarity | 0.941 |
| WER | 23.18% |
| UTMOS | 2.63 |
| silent / no-EOS | 0 / 0 |

Two caveats worth stating plainly, both in the model card:

- **WER reads against the corpus, not against your English numbers.** The same
  ASR on the eval set's *real* recordings scores 10.08%, because the reference
  transcripts are subtitle-derived. 23.18% is the gap over that floor.
- **UTMOS is capped by the data, not by training.** LEMAS audio is 16 kHz
  against Mimi's 24 kHz, so there is no energy above 8 kHz to learn. Training
  was stopped at step 87,500 of a planned 250,000 once it plateaued: WER moved
  0.6 points between steps 37,500 and 75,000 and validation loss was flat from
  42,500 on.

Speaker similarity is where it does well — above the released English model
(0.922) on a corpus of thousands of YouTube speakers rather than a few
narrators.

## Testing

The exact command in this diff was run from a cleared Hugging Face cache
against the published wheel via `uvx pocket-tts`, and separately against
v3.1.0 from source. Both generate; the pinned revision resolves.
