### PR TITLE
README: add Pocket-TTS-LiteRT (Android GPU) to alternative implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ We don't have official support for this yet, but you can try out one of these co
 - [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) by @csukuangfj - Run PocketTTS on **Windows, macOS, Linux**, and embedded boards (Raspberry Pi, Jetson, RK3588, etc.) with bindings for 12 programming languages: **C++, C, Python, JavaScript, Java, C#, Kotlin, Swift, Go, Dart, Rust, Pascal**, plus [WebAssembly](https://huggingface.co/spaces/k2-fsa/web-assembly-en-tts-pocket).
 - [pocket-tts-csharp](https://github.com/TheAjaykrishnanR/pocket-tts-csharp) by @TheAjaykrishnanR - A C# port of Pocket TTS implemented using [TorchSharp](https://github.com/dotnet/TorchSharp) and [TorchSharp.PyBridge](https://github.com/shaltielshmid/TorchSharp.PyBridge) for ease of use as a library in .NET projects.
 - [pocket-tts-timestamped](https://github.com/dpm63/pocket-tts-timestamped) by @dpm63 - A fork that adds support for word-level timestamps.
+- [Pocket-TTS-LiteRT](https://huggingface.co/mlboydaisuke/Pocket-TTS-LiteRT) by @john-rocky - LiteRT (.tflite) graphs that run on Android phone GPUs through the LiteRT CompiledModel API, ~1x real-time on a Pixel 8a, with Python and Kotlin usage snippets.
 
 ## Models trained by the community
 


### PR DESCRIPTION
Thanks for keeping the alternative-implementations list in the README. This adds one line to it for Pocket-TTS-LiteRT: the released checkpoint re-authored as LiteRT (.tflite) graphs that run on Android phone GPUs through the LiteRT CompiledModel API, with Python and Kotlin usage snippets on the card.

- Pixel 8a: 8.8 s of speech in 8.75 s, about 1x real-time; a Galaxy S26 run with the all-GPU placement reaches about 5x, and the placement notes are on the card.
- Parity against the eager reference: flow-LM step cond corr 1.000000; full free-running pipeline audio corr 0.997 with the same noise.
- Preset voices only (the CC BY 4.0 and CC0 ones); voice cloning is not included since the Mimi encoder weights are gated.
- License carried over as CC BY 4.0 with attribution to kyutai/pocket-tts.

Card: https://huggingface.co/mlboydaisuke/Pocket-TTS-LiteRT

Happy to reword or shorten the line to whatever fits the list. Thanks again.
