### PR TITLE
Decode every queued latent per call in the decoder thread

### DIFF
--- a/pocket_tts/models/tts_model.py
+++ b/pocket_tts/models/tts_model.py
@@ -101,6 +101,8 @@ class TTSModel(nn.Module):
     ):
         super().__init__()
         self.flow_lm = flow_lm
+        # 0 = decode every queued frame in one call; 1 = one frame per call
+        self.max_decoder_frames_per_call = 0
         self.temp = temp
         self.sampler_decode_steps = sampler_decode_steps
         self.noise_clamp = noise_clamp
@@ -508,23 +510,46 @@ class TTSModel(nn.Module):
                 latent = latents_queue.get()
                 if latent is None:
                     break
-                mimi_decoding_input = latent * self.flow_lm.emb_std + self.flow_lm.emb_mean
+                # Decode every latent frame the generator has queued in one call. The first frame
+                # never waits. max_decoder_frames_per_call=1 is frame-by-frame decoding.
+                latents = [latent]
+                finished = False
+                while not finished and (
+                    self.max_decoder_frames_per_call <= 0
+                    or len(latents) < self.max_decoder_frames_per_call
+                ):
+                    try:
+                        nxt = latents_queue.get_nowait()
+                    except queue.Empty:
+                        break
+                    if nxt is None:
+                        finished = True
+                    else:
+                        latents.append(nxt)
+                mimi_decoding_input = (
+                    torch.cat(latents, dim=1) * self.flow_lm.emb_std + self.flow_lm.emb_mean
+                )
 
                 t = time.monotonic()
                 audio_frame = self.mimi.decode_from_latent(mimi_decoding_input, mimi_state)
-                increment_steps(self.mimi, mimi_state, increment=mimi_steps_per_latent)
+                increment_steps(
+                    self.mimi, mimi_state, increment=mimi_steps_per_latent * len(latents)
+                )
                 audio_frame_duration = audio_frame.shape[2] / self.config.mimi.sample_rate
-                # We could log the timings here.
                 logger.debug(
-                    " " * 30 + "Decoded %d ms of audio with mimi in %d ms",
+                    " " * 30 + "Decoded %d ms of audio (%d frames) with mimi in %d ms",
                     int(audio_frame_duration * 1000),
+                    len(latents),
                     int((time.monotonic() - t) * 1000),
                 )
                 audio_chunks.append(audio_frame)
 
                 result_queue.put(("chunk", audio_frame))
 
-                latents_queue.task_done()
+                for _ in latents:
+                    latents_queue.task_done()
+                if finished:
+                    break
 
             # Signal completion
             result_queue.put(("done", None))


### PR DESCRIPTION
The decoder thread used to pop one latent from the queue and run the Mimi decoder on a single 80 ms frame per call. It now takes every latent that is already queued and decodes them in one streaming call, then blocks for the next one.

- Output is unchanged: the streaming decoder is exact for any number of frames (checked sample-identical on seeded generations).
- Latency is unchanged: only frames that are already waiting are batched, so the first frame never waits for a second one.
- `TTSModel.max_decoder_frames_per_call` (default 0 = every queued frame) set to 1 is frame-by-frame decoding.

Effect depends on which side is the bottleneck. With the released model on 4 CPU threads the flow LM is slower than the decoder, the queue rarely holds more than one frame, and speed is unchanged (2.4x real time either way on a Xeon Gold 6430). When the LM outruns the decoder, for instance on a GPU or with a faster LM, the decoder was the ceiling and this lifts it by 30 to 50% in our measurements.