### PR TITLE
README: collapse community model commands into <details> blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,47 +292,66 @@ uvx pocket-tts generate --config hf://user/repo/config_file.yaml@commit_hash
 
 ### List of community-trained models
 
-- [pocket-tts-czech](https://huggingface.co/vvolhejn/pocket-tts-czech) by @vvolhejn (trained internally at Kyutai):
+<details>
+<summary><a href="https://huggingface.co/vvolhejn/pocket-tts-czech">pocket-tts-czech</a> by @vvolhejn (trained internally at Kyutai)</summary>
+
 ```bash
 uvx pocket-tts generate \
   --config hf://vvolhejn/pocket-tts-czech/czech.yaml@7b7760dd0fe994a0800f2fdbc837dc4b8f219d1c \
   --text "Dnešek je velmi dobrý den"
 ```
+</details>
 
-- [Pocket TTS Hindi](https://huggingface.co/saryps-labs/pocket-tts-hindi) by [Saryps Labs](https://huggingface.co/saryps-labs) (community research release):
+<details>
+<summary><a href="https://huggingface.co/saryps-labs/pocket-tts-hindi">Pocket TTS Hindi</a> by <a href="https://huggingface.co/saryps-labs">Saryps Labs</a> (community research release)</summary>
+
 ```bash
 uvx pocket-tts generate \
   --config hf://saryps-labs/pocket-tts-hindi/config.yaml@dbaa326069d20bfbdaeb625613736773741a24ea \
   --text "आज का दिन बहुत अच्छा है"
 ```
+</details>
 
-- [Pocket TTS Korean 300M](https://huggingface.co/seastar105/pocket-tts-korean-300m) by [@seastar105](https://huggingface.co/seastar105) (community research release):
+<details>
+<summary><a href="https://huggingface.co/seastar105/pocket-tts-korean-300m">Pocket TTS Korean 300M</a> by <a href="https://huggingface.co/seastar105">@seastar105</a> (community research release)</summary>
+
 ```bash
 uvx pocket-tts generate \
   --config hf://seastar105/pocket-tts-korean-300m/korean.yaml@df328c817a02866f20a6f74e5183e0a1fc6f6435 \
   --text "안녕하세요. 한국어 음성 합성 모델입니다."
 ```
-- [Pocket TTS Persian (Farsi)](https://huggingface.co/mehdi-hf/pocket-tts-farsi) by @mallahyari (community research release):
+</details>
+
+<details>
+<summary><a href="https://huggingface.co/mehdi-hf/pocket-tts-farsi">Pocket TTS Persian (Farsi)</a> by @mallahyari (community research release)</summary>
+
 ```bash
 uvx --with soundfile pocket-tts generate --config hf://mehdi-hf/pocket-tts-farsi/farsi.yaml@3c59d06b3177b21c5cd0df9e9e3e899f4d361c1c \
     --voice hf://mehdi-hf/pocket-tts-farsi/example_voice.wav --text "سلام، حال شما چطور است؟"
 ```
+</details>
 
-- [Pocket TTS Indonesian](https://huggingface.co/anak10thn/pocket-tts-indonesian) by [@anak10thn](https://huggingface.co/anak10thn) (community research release), 6 layers:
+<details>
+<summary><a href="https://huggingface.co/anak10thn/pocket-tts-indonesian">Pocket TTS Indonesian</a> by <a href="https://huggingface.co/anak10thn">@anak10thn</a> (community research release), 6 layers</summary>
+
 ```bash
 uvx pocket-tts generate \
   --config hf://anak10thn/pocket-tts-indonesian/indonesian_6l.yaml@635cde7a28301861b120f57ec4dda8525073017c \
   --eos-threshold -5.0 \
   --text "Selamat pagi. Ini model sintesis suara bahasa Indonesia."
 ```
+</details>
 
-- [Pocket TTS Estonian](https://huggingface.co/cbentes/pocket-tts-estonian) by @cbentes (community research release):
+<details>
+<summary><a href="https://huggingface.co/cbentes/pocket-tts-estonian">Pocket TTS Estonian</a> by @cbentes (community research release)</summary>
+
 ```bash
 uvx pocket-tts generate \
   --config hf://cbentes/pocket-tts-estonian/estonian.yaml@8934022f1befb3dc568351e3b88e48a9edb94d7d \
   --voice hf://cbentes/pocket-tts-estonian/voices/et_f_reporter.wav@8934022f1befb3dc568351e3b88e48a9edb94d7d \
   --text "Tere! Mina olen eesti keele kõnesüntesaator ja töötan tavalises arvutis kiiremini kui reaalajas."
 ```
+</details>
 
 Want your model here? Head to the [training Readme](https://github.com/kyutai-labs/pocket-tts/blob/main/training/README.md) to get started!
 

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ uvx pocket-tts generate --config hf://user/repo/config_file.yaml@commit_hash
 ### List of community-trained models
 
 <details>
-<summary><a href="https://huggingface.co/vvolhejn/pocket-tts-czech">pocket-tts-czech</a> by @vvolhejn (trained internally at Kyutai)</summary>
+<summary><a href="https://huggingface.co/vvolhejn/pocket-tts-czech">Pocket TTS Czech</a> by @vvolhejn (trained internally at Kyutai)</summary>
 
 ```bash
 uvx pocket-tts generate \


### PR DESCRIPTION
The list of community-trained models spent 5-7 lines per entry on its command line, which made it hard to scan as more models get added.

Each entry is now a single-line `<details>` summary that expands to the exact same `bash` block — and GitHub's own copy button on the code block covers the copy-paste case.

No command was changed, only the wrapping.