### PR TITLE
Bump the Indonesian model to its retrained weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,8 +336,7 @@ uvx --with soundfile pocket-tts generate --config hf://mehdi-hf/pocket-tts-farsi
 
 ```bash
 uvx pocket-tts generate \
-  --config hf://anak10thn/pocket-tts-indonesian/indonesian_6l.yaml@635cde7a28301861b120f57ec4dda8525073017c \
-  --eos-threshold -5.0 \
+  --config hf://anak10thn/pocket-tts-indonesian/indonesian_6l.yaml@6196fe14c6c2108332c16d33c864c8901c044aaa \
   --text "Selamat pagi. Ini model sintesis suara bahasa Indonesia."
 ```
 </details>


### PR DESCRIPTION
The 6-layer student was retrained after finding its training targets were being
cut off mid-word. The loader trims each target to the last aligned word plus a
0.2s tail, which is right for a corpus padded with silence -- but LEMAS clips
are cropped tight around speech while its aligner ends early. Speech continues
past the last aligned word by 0.15s at the median and 0.52s at p90, so 0.2s
covered only 62% of clips and truncated the targets in the rest. 0.6s covers
99%.

Measured on 153 held-out cross-sentence pairs, Whisper-large-v3 pinned to
Indonesian, each model at its own best eos:

| | previous pin | this pin |
|---|---|---|
| median per-item WER | 12.50% | **9.09%** |
| corpus WER | 24.44% | **13.48%** |
| items over 50% WER | 7 | **4** |
| silent generations | 2 | **0** |
| 87-word passage | 21.35% | **6.74%** |
| speaker similarity / UTMOS | 0.938 / 2.68 | 0.939 / 2.68 |

**Also dropping `--eos-threshold` from the example.** The previous weights
genuinely needed it: -6.0 was best on short input but lost whole chunks of long
text, so -5.0 was the compromise I asked you to carry. The retrain removed that
split, and for a single short sentence the flag makes no difference at all --
three generations with it and three without, all 0.00% WER, durations
overlapping. It was measured on 153 pairs and belongs in the model card, not in
a one-sentence example here.

Command run as written from a cleared cache via `uvx`.
