### PR TITLE
Add capitalize_first_letter so phoneme models are not capitalized

### DIFF
--- a/pocket_tts/models/text_chunking.py
+++ b/pocket_tts/models/text_chunking.py
@@ -16,6 +16,7 @@ def prepare_text_prompt(
     pad_with_spaces_for_short_inputs: bool,
     remove_semicolons: bool,
     append_terminal_punctuation: bool = True,
+    capitalize_first_letter: bool = True,
 ) -> tuple[str, int]:
     text = text.strip()
     if text == "":
@@ -29,8 +30,9 @@ def prepare_text_prompt(
     else:
         frames_after_eos_guess = 1
 
-    # Make sure it starts with an uppercase letter
-    if not text[0].isupper():
+    # Make sure it starts with an uppercase letter. Only meaningful for
+    # orthographies that have case; see Config.capitalize_first_letter.
+    if capitalize_first_letter and not text[0].isupper():
         text = text[0].upper() + text[1:]
 
     if append_terminal_punctuation:
@@ -138,12 +140,14 @@ def split_into_best_sentences(
     pad_with_spaces_for_short_inputs: bool,
     remove_semicolons: bool,
     append_terminal_punctuation: bool = True,
+    capitalize_first_letter: bool = True,
 ) -> list[str]:
     text_to_generate, _ = prepare_text_prompt(
         text_to_generate,
         pad_with_spaces_for_short_inputs,
         remove_semicolons,
         append_terminal_punctuation,
+        capitalize_first_letter,
     )
     text_to_generate = text_to_generate.strip()
     tokens = tokenizer(text_to_generate)

--- a/pocket_tts/models/tts_model.py
+++ b/pocket_tts/models/tts_model.py
@@ -98,6 +98,7 @@ class TTSModel(nn.Module):
         model_recommended_frames_after_eos: int | None = None,
         remove_semicolons: bool = False,
         append_terminal_punctuation: bool = True,
+        capitalize_first_letter: bool = True,
     ):
         super().__init__()
         self.flow_lm = flow_lm
@@ -114,6 +115,7 @@ class TTSModel(nn.Module):
         self.model_recommended_frames_after_eos = model_recommended_frames_after_eos
         self.remove_semicolons = remove_semicolons
         self.append_terminal_punctuation = append_terminal_punctuation
+        self.capitalize_first_letter = capitalize_first_letter
 
     @property
     def device(self) -> torch.device:
@@ -150,6 +152,7 @@ class TTSModel(nn.Module):
             model_recommended_frames_after_eos=config.model_recommended_frames_after_eos,
             remove_semicolons=config.remove_semicolons,
             append_terminal_punctuation=config.append_terminal_punctuation,
+            capitalize_first_letter=config.capitalize_first_letter,
         )
         return tts_model
 
@@ -699,6 +702,7 @@ class TTSModel(nn.Module):
             self.pad_with_spaces_for_short_inputs,
             remove_semicolons=self.remove_semicolons,
             append_terminal_punctuation=self.append_terminal_punctuation,
+            capitalize_first_letter=self.capitalize_first_letter,
         )
 
         for chunk in chunks:
@@ -707,6 +711,7 @@ class TTSModel(nn.Module):
                 self.pad_with_spaces_for_short_inputs,
                 self.remove_semicolons,
                 self.append_terminal_punctuation,
+                self.capitalize_first_letter,
             )
             frames_after_eos_guess += 2
             effective_frames = (

--- a/pocket_tts/utils/config.py
+++ b/pocket_tts/utils/config.py
@@ -121,6 +121,13 @@ class Config(StrictModel):
     pad_with_spaces_for_short_inputs: bool = False
     remove_semicolons: bool = False
     append_terminal_punctuation: bool = True
+    # Upper-casing the first letter is an orthographic convention of the
+    # Latin-script languages this model shipped with. A model whose text is
+    # romanised phonemes must switch it off: the capital is not in the phoneme
+    # inventory, so the first word's onset becomes the unknown token, and where
+    # a capital *is* a phoneme it silently changes the sound ("salAm" -> "SalAm"
+    # is /salaam/ -> /shalaam/).
+    capitalize_first_letter: bool = True
     model_recommended_frames_after_eos: int | None = None
     default_temperature: float = 0.7
 

--- a/tests/test_generation_regressions.py
+++ b/tests/test_generation_regressions.py
@@ -21,10 +21,12 @@ def test_generate_audio_stream_uses_prepared_chunk_text(monkeypatch: pytest.Monk
         pad_with_spaces_for_short_inputs: bool,
         remove_semicolons: bool,
         append_terminal_punctuation: bool,
+        capitalize_first_letter: bool,
     ) -> list[str]:
         assert text_to_generate == "hi"
         assert pad_with_spaces_for_short_inputs is True
         assert append_terminal_punctuation is True
+        assert capitalize_first_letter is True
         return ["hi"]
 
     def fake_generate_audio_stream_short_text(**kwargs: object) -> Iterator[torch.Tensor]:
@@ -42,6 +44,7 @@ def test_generate_audio_stream_uses_prepared_chunk_text(monkeypatch: pytest.Monk
             pad_with_spaces_for_short_inputs=True,
             remove_semicolons=False,
             append_terminal_punctuation=True,
+            capitalize_first_letter=True,
             _generate_audio_stream_short_text=fake_generate_audio_stream_short_text,
         ),
     )

--- a/tests/test_split_sentences.py
+++ b/tests/test_split_sentences.py
@@ -232,3 +232,26 @@ def test_terminal_punctuation_is_added_when_missing(text: str, expected: str):
         text, pad_with_spaces_for_short_inputs=False, remove_semicolons=False
     )
     assert got == expected
+
+
+def test_capitalization_can_be_switched_off():
+    """A model whose text is phonemes, not spelling, must not be capitalized.
+
+    Capitalizing rewrites the first sound of the first word. In a romanized
+    phoneme alphabet the capital is usually absent from the vocabulary, so the
+    opening word becomes the unknown token and is not spoken at all; and where a
+    capital *is* a phoneme it changes the sound silently rather than erroring.
+    Both were observed in a Persian model whose alphabet uses "S" for sh: "salAm"
+    was capitalized to "SalAm" and came out as /shalaam/.
+    """
+    kwargs = dict(pad_with_spaces_for_short_inputs=False, remove_semicolons=False)
+
+    on, _ = prepare_text_prompt("salAm hAle SomA", **kwargs)
+    assert on.startswith("SalAm")
+
+    off, _ = prepare_text_prompt("salAm hAle SomA", capitalize_first_letter=False, **kwargs)
+    assert off.startswith("salAm")
+
+    # The default is unchanged, so nothing moves for the shipped languages.
+    default, _ = prepare_text_prompt("hello there", **kwargs)
+    assert default == "Hello there."


### PR DESCRIPTION
Add capitalize_first_letter so phoneme models are not capitalized

`prepare_text_prompt` upper-cases the first letter of every chunk. That is right for the Latin-script languages pocket-tts ships with, and wrong for a model whose text is romanized phonemes rather than spelling, because the capital is a different symbol from the lowercase one.

Two ways it goes wrong, both silent.

If the capital is absent from the vocabulary, the opening word becomes the unknown token and is not spoken at all:

```
in  : man be bAzAr raftam
out : ⁇ an be bAzAr raftam ⁇.
      tokens: ["▁?", "?", "▁", "an", "▁be", ...]
```

If the capital *is* a phoneme, the sound changes instead. We hit both while training a Persian model whose alphabet uses `S` for *sh*: `salAm` was capitalized to `SalAm` and came out as /shalaam/.

It is easy to miss. Words beginning with a symbol that has no uppercase form are untouched, since `"?".upper()` is `"?"`, so the defect looks lexical rather than systematic and prepending any such word appears to fix it. It also never appears in an evaluation harness that tokenizes text itself and calls the model directly, which is what ours did: the evaluation measured a model that was fine while the shipping path produced one that was not. On our probe set the first word was rendered correctly 5 times in 50 before the fix and 40 in 50 after, with no change to the same word one position later.

## The change

`capitalize_first_letter` on `Config`, defaulting to `True`, threaded through `prepare_text_prompt` and `split_into_best_sentences` the same way the neighbouring text-prep flags are. Nothing changes for the shipped models.

## Tests

`tests/test_split_sentences.py` gains a case covering both directions: a phoneme prompt keeps its case when the flag is off, and the default still capitalizes and adds terminal punctuation. `tests/test_generation_regressions.py` is updated for the new keyword in the call it pins. Full suite passes (68).